### PR TITLE
♻️ refactor: update controllers to use the new ts-rest API

### DIFF
--- a/apps/api/src/modules/athlete-session/athlete-session.controller.ts
+++ b/apps/api/src/modules/athlete-session/athlete-session.controller.ts
@@ -4,154 +4,146 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { AthleteSessionService } from './athlete-session.service';
 
-const c = nestControllerContract(apiContract.athleteSession);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = apiContract.athleteSession;
 
 @Controller()
-export class AthleteSessionController
-  implements NestControllerInterface<typeof apiContract.athleteSession>
-{
+export class AthleteSessionController {
   constructor(private readonly athleteSessionService: AthleteSessionService) {}
 
-  @TsRest(c.getAthleteSessions)
-  async getAthleteSessions(
-    @TsRestRequest() request: RequestShapes['getAthleteSessions']
-  ) {
-    try {
-      const athleteSessions =
-        await this.athleteSessionService.getAthleteSessions();
-      return { status: 200 as const, body: athleteSessions };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getAthleteSessions)
+  async getAthleteSessions() {
+    return tsRestHandler(c.getAthleteSessions, async () => {
+      try {
+        const athleteSessions =
+          await this.athleteSessionService.getAthleteSessions();
+        return { status: 200, body: athleteSessions };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getAthleteSession)
-  async getAthleteSession(
-    @TsRestRequest() { params }: RequestShapes['getAthleteSession']
-  ) {
-    try {
-      const athleteSession = await this.athleteSessionService.getAthleteSession(
-        params.athleteId,
-        params.sessionId
-      );
-      return { status: 200 as const, body: athleteSession };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getAthleteSession)
+  async getAthleteSession() {
+    return tsRestHandler(c.getAthleteSession, async ({ params }) => {
+      try {
+        const athleteSession =
+          await this.athleteSessionService.getAthleteSession(
+            params.athleteId,
+            params.sessionId
+          );
+        return { status: 200, body: athleteSession };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getAthleteSessionsByAthlete)
-  async getAthleteSessionsByAthlete(
-    @TsRestRequest() { params }: RequestShapes['getAthleteSessionsByAthlete']
-  ) {
-    try {
-      const athleteSessions =
-        await this.athleteSessionService.getAthleteSessionsByAthlete(
-          params.athleteId
-        );
-      return { status: 200 as const, body: athleteSessions };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getAthleteSessionsByAthlete)
+  async getAthleteSessionsByAthlete() {
+    return tsRestHandler(c.getAthleteSessionsByAthlete, async ({ params }) => {
+      try {
+        const athleteSessions =
+          await this.athleteSessionService.getAthleteSessionsByAthlete(
+            params.athleteId
+          );
+        return { status: 200, body: athleteSessions };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getAthleteSessionsBySession)
-  async getAthleteSessionsBySession(
-    @TsRestRequest() { params }: RequestShapes['getAthleteSessionsBySession']
-  ) {
-    try {
-      const athleteSessions =
-        await this.athleteSessionService.getAthleteSessionsBySession(
+  @TsRestHandler(c.getAthleteSessionsBySession)
+  async getAthleteSessionsBySession() {
+    return tsRestHandler(c.getAthleteSessionsBySession, async ({ params }) => {
+      try {
+        const athleteSessions =
+          await this.athleteSessionService.getAthleteSessionsBySession(
+            params.sessionId
+          );
+        return { status: 200, body: athleteSessions };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
+      }
+    });
+  }
+
+  @TsRestHandler(c.createAthleteSession)
+  async createAthleteSession() {
+    return tsRestHandler(c.createAthleteSession, async ({ body }) => {
+      try {
+        const newAthleteSession =
+          await this.athleteSessionService.createAthleteSession(body);
+        return { status: 201, body: newAthleteSession };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return { status: 400, body: { message: error.message } };
+        }
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
+      }
+    });
+  }
+
+  @TsRestHandler(c.updateAthleteSession)
+  async updateAthleteSession() {
+    return tsRestHandler(c.updateAthleteSession, async ({ params, body }) => {
+      try {
+        const updatedAthleteSession =
+          await this.athleteSessionService.updateAthleteSession(
+            params.athleteId,
+            params.sessionId,
+            body
+          );
+        return { status: 200, body: updatedAthleteSession };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return { status: 400, body: { message: error.message } };
+        }
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
+      }
+    });
+  }
+
+  @TsRestHandler(c.deleteAthleteSession)
+  async deleteAthleteSession() {
+    return tsRestHandler(c.deleteAthleteSession, async ({ params }) => {
+      try {
+        await this.athleteSessionService.deleteAthleteSession(
+          params.athleteId,
           params.sessionId
         );
-      return { status: 200 as const, body: athleteSessions };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+        return {
+          status: 200,
+          body: { message: 'AthleteSession deleted successfully' },
+        };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
-  }
-
-  @TsRest(c.createAthleteSession)
-  async createAthleteSession(
-    @TsRestRequest() { body }: RequestShapes['createAthleteSession']
-  ) {
-    try {
-      const newAthleteSession =
-        await this.athleteSessionService.createAthleteSession(body);
-      return { status: 201 as const, body: newAthleteSession };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
-        return { status: 400 as const, body: { message: error.message } };
-      }
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
-      }
-      throw error;
-    }
-  }
-
-  @TsRest(c.updateAthleteSession)
-  async updateAthleteSession(
-    @TsRestRequest() { params, body }: RequestShapes['updateAthleteSession']
-  ) {
-    try {
-      const updatedAthleteSession =
-        await this.athleteSessionService.updateAthleteSession(
-          params.athleteId,
-          params.sessionId,
-          body
-        );
-      return { status: 200 as const, body: updatedAthleteSession };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
-        return { status: 400 as const, body: { message: error.message } };
-      }
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
-      }
-      throw error;
-    }
-  }
-
-  @TsRest(c.deleteAthleteSession)
-  async deleteAthleteSession(
-    @TsRestRequest() { params }: RequestShapes['deleteAthleteSession']
-  ) {
-    try {
-      await this.athleteSessionService.deleteAthleteSession(
-        params.athleteId,
-        params.sessionId
-      );
-      return {
-        status: 200 as const,
-        body: { message: 'AthleteSession deleted successfully' },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
-      }
-      throw error;
-    }
+    });
   }
 }

--- a/apps/api/src/modules/complex-category/complex-category.controller.ts
+++ b/apps/api/src/modules/complex-category/complex-category.controller.ts
@@ -4,150 +4,138 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { ComplexCategoryService } from './complex-category.service';
 
-const c = nestControllerContract(complexCategoryContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = complexCategoryContract;
 
 @Controller()
-export class ComplexCategoryController
-  implements NestControllerInterface<typeof c>
-{
+export class ComplexCategoryController {
   constructor(
     private readonly complexCategoryService: ComplexCategoryService
   ) {}
 
-  @TsRest(c.getComplexCategories)
-  async getComplexCategories(
-    @TsRestRequest() request: RequestShapes['getComplexCategories']
-  ) {
-    try {
-      const complexCategory =
-        await this.complexCategoryService.getComplexCategories();
-      return {
-        status: 200 as const,
-        body: complexCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getComplexCategories)
+  async getComplexCategories() {
+    return tsRestHandler(c.getComplexCategories, async () => {
+      try {
+        const complexCategory =
+          await this.complexCategoryService.getComplexCategories();
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: complexCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getComplexCategory)
-  async getComplexCategory(
-    @TsRestRequest()
-    { params }: RequestShapes['getComplexCategory']
-  ) {
-    try {
-      const complexCategory =
-        await this.complexCategoryService.getComplexCategory(params.id);
-      return {
-        status: 200 as const,
-        body: complexCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getComplexCategory)
+  async getComplexCategory() {
+    return tsRestHandler(c.getComplexCategory, async ({ params }) => {
+      try {
+        const complexCategory =
+          await this.complexCategoryService.getComplexCategory(params.id);
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: complexCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.createComplexCategory)
-  async createComplexCategory(
-    @TsRestRequest() { body }: RequestShapes['createComplexCategory']
-  ) {
-    try {
-      const complexCategory =
-        await this.complexCategoryService.createComplexCategory(body);
-      return {
-        status: 201 as const,
-        body: complexCategory,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createComplexCategory)
+  async createComplexCategory() {
+    return tsRestHandler(c.createComplexCategory, async ({ body }) => {
+      try {
+        const complexCategory =
+          await this.complexCategoryService.createComplexCategory(body);
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 201,
+          body: complexCategory,
         };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.updateComplexCategory)
-  async updateComplexCategory(
-    @TsRestRequest()
-    { params, body }: RequestShapes['updateComplexCategory']
-  ) {
-    try {
-      const complexCategory =
-        await this.complexCategoryService.updateComplexCategory(
-          params.id,
-          body
-        );
-      return {
-        status: 200 as const,
-        body: complexCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.updateComplexCategory)
+  async updateComplexCategory() {
+    return tsRestHandler(c.updateComplexCategory, async ({ params, body }) => {
+      try {
+        const complexCategory =
+          await this.complexCategoryService.updateComplexCategory(
+            params.id,
+            body
+          );
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: complexCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.deleteComplexCategory)
-  async deleteComplexCategory(
-    @TsRestRequest()
-    { params }: RequestShapes['deleteComplexCategory']
-  ) {
-    try {
-      await this.complexCategoryService.deleteComplexCategory(params.id);
-      return {
-        status: 200 as const,
-        body: {
-          message: 'Complex category deleted successfully',
-        },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.deleteComplexCategory)
+  async deleteComplexCategory() {
+    return tsRestHandler(c.deleteComplexCategory, async ({ params }) => {
+      try {
+        await this.complexCategoryService.deleteComplexCategory(params.id);
         return {
-          status: 404 as const,
+          status: 200,
           body: {
-            message: error.message,
+            message: 'Complex category deleted successfully',
           },
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 }

--- a/apps/api/src/modules/complex/complex.controller.ts
+++ b/apps/api/src/modules/complex/complex.controller.ts
@@ -4,118 +4,114 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestHandler,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { ComplexService } from './complex.service';
 
-const c = nestControllerContract(complexContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = complexContract;
 
 @Controller()
-export class ComplexController implements NestControllerInterface<typeof c> {
+export class ComplexController {
   constructor(private readonly complexService: ComplexService) {}
 
-  @TsRest(c.getComplexes)
-  async getComplexes(@TsRestRequest() request: RequestShapes['getComplexes']) {
-    try {
-      const complexes = await this.complexService.getComplexes();
+  @TsRestHandler(c.getComplexes)
+  async getComplexes() {
+    return tsRestHandler(c.getComplexes, async () => {
+      try {
+        const complexes = await this.complexService.getComplexes();
 
-      return {
-        status: 200 as const,
-        body: complexes,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: complexes,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.getComplex)
-  async getComplex(@TsRestRequest() { params }: RequestShapes['getComplex']) {
-    try {
-      const complex = await this.complexService.getComplex(params.id);
-      return {
-        status: 200 as const,
-        body: complex,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getComplex)
+  async getComplex() {
+    return tsRestHandler(c.getComplex, async ({ params }) => {
+      try {
+        const complex = await this.complexService.getComplex(params.id);
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: complex,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.createComplex)
-  async createComplex(
-    @TsRestRequest() { body }: RequestShapes['createComplex']
-  ) {
-    try {
-      const newComplex = await this.complexService.createComplex(body);
-      return {
-        status: 201 as const,
-        body: newComplex,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createComplex)
+  async createComplex() {
+    return tsRestHandler(c.createComplex, async ({ body }) => {
+      try {
+        const newComplex = await this.complexService.createComplex(body);
         return {
-          status: 400 as const,
-          body: { message: error.message },
+          status: 201,
+          body: newComplex,
         };
-      }
-      if (error instanceof NotFoundException) {
-        return {
-          status: 404 as const,
-          body: { message: error.message },
-        };
-      }
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: { message: error.message },
+          };
+        }
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.updateComplex)
-  async updateComplex(
-    @TsRestRequest() { params, body }: RequestShapes['updateComplex']
-  ) {
-    try {
-      const updatedComplex = await this.complexService.updateComplex(
-        params.id,
-        body
-      );
-      return {
-        status: 200 as const,
-        body: updatedComplex,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.updateComplex)
+  async updateComplex() {
+    return tsRestHandler(c.updateComplex, async ({ params, body }) => {
+      try {
+        const updatedComplex = await this.complexService.updateComplex(
+          params.id,
+          body
+        );
         return {
-          status: 404 as const,
-          body: { message: error.message },
+          status: 200,
+          body: updatedComplex,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 }

--- a/apps/api/src/modules/exercise/exercise.controller.ts
+++ b/apps/api/src/modules/exercise/exercise.controller.ts
@@ -4,167 +4,163 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestHandler,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { ExerciseService } from './exercise.service';
 
-const c = nestControllerContract(exerciseContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = exerciseContract;
 
 @Controller()
-export class ExerciseController implements NestControllerInterface<typeof c> {
+export class ExerciseController {
   constructor(private readonly exerciseService: ExerciseService) {}
 
-  @TsRest(c.getExercises)
-  async getExercises(@TsRestRequest() request: RequestShapes['getExercises']) {
-    try {
-      const exercises = await this.exerciseService.getExercises();
+  @TsRestHandler(c.getExercises)
+  async getExercises() {
+    return tsRestHandler(c.getExercises, async () => {
+      try {
+        const exercises = await this.exerciseService.getExercises();
 
-      return {
-        status: 200 as const,
-        body: exercises,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: exercises,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.getExercise)
-  async getExercise(@TsRestRequest() { params }: RequestShapes['getExercise']) {
-    try {
-      const exercise = await this.exerciseService.getExercise(params.id);
+  @TsRestHandler(c.getExercise)
+  async getExercise() {
+    return tsRestHandler(c.getExercise, async ({ params }) => {
+      try {
+        const exercise = await this.exerciseService.getExercise(params.id);
 
-      return {
-        status: 200 as const,
-        body: exercise,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: { message: error.message },
+          status: 200,
+          body: exercise,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.createExercise)
-  async createExercise(
-    @TsRestRequest() { body }: RequestShapes['createExercise']
-  ) {
-    try {
-      const newExercise = await this.exerciseService.createExercise(body);
-      return {
-        status: 201 as const,
-        body: newExercise,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createExercise)
+  async createExercise() {
+    return tsRestHandler(c.createExercise, async ({ body }) => {
+      try {
+        const newExercise = await this.exerciseService.createExercise(body);
         return {
-          status: 400 as const,
-          body: { message: error.message },
+          status: 201,
+          body: newExercise,
         };
-      }
-      if (error instanceof NotFoundException) {
-        return {
-          status: 404 as const,
-          body: { message: error.message },
-        };
-      }
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: { message: error.message },
+          };
+        }
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.updateExercise)
-  async updateExercise(
-    @TsRestRequest() { params, body }: RequestShapes['updateExercise']
-  ) {
-    try {
-      const updatedExercise = await this.exerciseService.updateExercise(
-        params.id,
-        body
-      );
+  @TsRestHandler(c.updateExercise)
+  async updateExercise() {
+    return tsRestHandler(c.updateExercise, async ({ params, body }) => {
+      try {
+        const updatedExercise = await this.exerciseService.updateExercise(
+          params.id,
+          body
+        );
 
-      return {
-        status: 200 as const,
-        body: updatedExercise,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: { message: error.message },
+          status: 200,
+          body: updatedExercise,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.deleteExercise)
-  async deleteExercise(
-    @TsRestRequest() { params }: RequestShapes['deleteExercise']
-  ) {
-    try {
-      await this.exerciseService.deleteExercise(params.id);
+  @TsRestHandler(c.deleteExercise)
+  async deleteExercise() {
+    return tsRestHandler(c.deleteExercise, async ({ params }) => {
+      try {
+        await this.exerciseService.deleteExercise(params.id);
 
-      return {
-        status: 200 as const,
-        body: { message: 'Exercise deleted successfully' },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: { message: error.message },
+          status: 200,
+          body: { message: 'Exercise deleted successfully' },
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
   @TsRestHandler(c.searchExercises)
-  async searchExercises(
-    @TsRestRequest() { query }: RequestShapes['searchExercises']
-  ) {
-    try {
-      // Contrat : query = { like: z.string() }
-      const exerciseFound = await this.exerciseService.searchExercises(
-        query.like
-      );
+  async searchExercises() {
+    return tsRestHandler(c.searchExercises, async ({ query }) => {
+      try {
+        // Contrat : query = { like: z.string() }
+        const exerciseFound = await this.exerciseService.searchExercises(
+          query.like
+        );
 
-      return {
-        status: 200 as const,
-        body: exerciseFound,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: { message: error.message },
+          status: 200,
+          body: exerciseFound,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: { message: error.message },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 }

--- a/apps/api/src/modules/exerciseCategory/exerciseCategory.controller.ts
+++ b/apps/api/src/modules/exerciseCategory/exerciseCategory.controller.ts
@@ -4,149 +4,139 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { ExerciseCategoryService } from './exerciseCategory.service';
 
-const c = nestControllerContract(exerciseCategoryContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = exerciseCategoryContract;
 
 @Controller()
-export class ExerciseCategoryController
-  implements NestControllerInterface<typeof c>
-{
+export class ExerciseCategoryController {
   constructor(
     private readonly exerciseCategoryService: ExerciseCategoryService
   ) {}
 
-  @TsRest(c.getExerciseCategories)
-  async getExerciseCategories(
-    @TsRestRequest() request: RequestShapes['getExerciseCategories']
-  ) {
-    try {
-      const exerciseCategories =
-        await this.exerciseCategoryService.getExerciseCategories();
-      return {
-        status: 200 as const,
-        body: exerciseCategories,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getExerciseCategories)
+  async getExerciseCategories() {
+    return tsRestHandler(c.getExerciseCategories, async () => {
+      try {
+        const exerciseCategories =
+          await this.exerciseCategoryService.getExerciseCategories();
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: exerciseCategories,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getExerciseCategory)
-  async getExerciseCategory(
-    @TsRestRequest()
-    { params }: RequestShapes['getExerciseCategory']
-  ) {
-    try {
-      const exerciseCategory =
-        await this.exerciseCategoryService.getExerciseCategory(params.id);
-      return {
-        status: 200 as const,
-        body: exerciseCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getExerciseCategory)
+  async getExerciseCategory() {
+    return tsRestHandler(c.getExerciseCategory, async ({ params }) => {
+      try {
+        const exerciseCategory =
+          await this.exerciseCategoryService.getExerciseCategory(params.id);
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: exerciseCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.createExerciseCategory)
-  async createExerciseCategory(
-    @TsRestRequest() { body }: RequestShapes['createExerciseCategory']
-  ) {
-    try {
-      const newExerciseCategory =
-        await this.exerciseCategoryService.createExerciseCategory(body);
-      return {
-        status: 201 as const,
-        body: newExerciseCategory,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createExerciseCategory)
+  async createExerciseCategory() {
+    return tsRestHandler(c.createExerciseCategory, async ({ body }) => {
+      try {
+        const newExerciseCategory =
+          await this.exerciseCategoryService.createExerciseCategory(body);
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 201,
+          body: newExerciseCategory,
         };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.updateExerciseCategory)
-  async updateExerciseCategory(
-    @TsRestRequest() { params, body }: RequestShapes['updateExerciseCategory']
-  ) {
-    try {
-      const updatedExerciseCategory =
-        await this.exerciseCategoryService.updateExerciseCategory(
-          params.id,
-          body
-        );
-      return {
-        status: 200 as const,
-        body: updatedExerciseCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.updateExerciseCategory)
+  async updateExerciseCategory() {
+    return tsRestHandler(c.updateExerciseCategory, async ({ params, body }) => {
+      try {
+        const updatedExerciseCategory =
+          await this.exerciseCategoryService.updateExerciseCategory(
+            params.id,
+            body
+          );
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: updatedExerciseCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.deleteExerciseCategory)
-  async deleteExerciseCategory(
-    @TsRestRequest() { params }: RequestShapes['deleteExerciseCategory']
-  ) {
-    try {
-      await this.exerciseCategoryService.deleteExerciseCategory(params.id);
+  @TsRestHandler(c.deleteExerciseCategory)
+  async deleteExerciseCategory() {
+    return tsRestHandler(c.deleteExerciseCategory, async ({ params }) => {
+      try {
+        await this.exerciseCategoryService.deleteExerciseCategory(params.id);
 
-      return {
-        status: 200 as const,
-        body: {
-          message: 'Exercise category deleted successfully',
-        },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
+          status: 200,
           body: {
-            message: error.message,
+            message: 'Exercise category deleted successfully',
           },
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 }

--- a/apps/api/src/modules/session/session.controller.ts
+++ b/apps/api/src/modules/session/session.controller.ts
@@ -4,139 +4,134 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import {
-  NestControllerInterface,
-  NestRequestShapes,
-  TsRest,
-  TsRestRequest,
-  nestControllerContract,
-} from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { SessionService } from './session.service';
 
-const c = nestControllerContract(apiContract.session);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = apiContract.session;
 
 @Controller()
-export class SessionController
-  implements NestControllerInterface<typeof apiContract.session>
-{
+export class SessionController {
   constructor(private readonly sessionService: SessionService) {}
 
-  @TsRest(c.getSessions)
-  async getSessions(@TsRestRequest() request: RequestShapes['getSessions']) {
-    try {
-      const sessions = await this.sessionService.getSessions();
-      return { status: 200 as const, body: sessions };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getSessions)
+  async getSessions() {
+    return tsRestHandler(c.getSessions, async () => {
+      try {
+        const sessions = await this.sessionService.getSessions();
+        return { status: 200, body: sessions };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getSession)
-  async getSession(@TsRestRequest() { params }: RequestShapes['getSession']) {
-    try {
-      const session = await this.sessionService.getSession(params.id);
-      return { status: 200 as const, body: session };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getSession)
+  async getSession() {
+    return tsRestHandler(c.getSession, async ({ params }) => {
+      try {
+        const session = await this.sessionService.getSession(params.id);
+        return { status: 200, body: session };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getSessionsByAthlete)
-  async getSessionsByAthlete(
-    @TsRestRequest() { params }: RequestShapes['getSessionsByAthlete']
-  ) {
-    try {
-      const sessions = await this.sessionService.getSessionsByAthlete(
-        params.athleteId
-      );
-      return { status: 200 as const, body: sessions };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.getSessionsByAthlete)
+  async getSessionsByAthlete() {
+    return tsRestHandler(c.getSessionsByAthlete, async ({ params }) => {
+      try {
+        const sessions = await this.sessionService.getSessionsByAthlete(
+          params.athleteId
+        );
+        return { status: 200, body: sessions };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.createSession)
-  async createSession(
-    @TsRestRequest() { body }: RequestShapes['createSession']
-  ) {
-    try {
-      const newSession = await this.sessionService.createSession(body);
-      return { status: 201 as const, body: newSession };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
-        return { status: 400 as const, body: { message: error.message } };
+  @TsRestHandler(c.createSession)
+  async createSession() {
+    return tsRestHandler(c.createSession, async ({ body }) => {
+      try {
+        const newSession = await this.sessionService.createSession(body);
+        return { status: 201, body: newSession };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return { status: 400, body: { message: error.message } };
+        }
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
-      }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.updateSession)
-  async updateSession(
-    @TsRestRequest() { params, body }: RequestShapes['updateSession']
-  ) {
-    try {
-      const updatedSession = await this.sessionService.updateSession(
-        params.id,
-        body
-      );
-      return { status: 200 as const, body: updatedSession };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
-        return { status: 400 as const, body: { message: error.message } };
+  @TsRestHandler(c.updateSession)
+  async updateSession() {
+    return tsRestHandler(c.updateSession, async ({ params, body }) => {
+      try {
+        const updatedSession = await this.sessionService.updateSession(
+          params.id,
+          body
+        );
+        return { status: 200, body: updatedSession };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return { status: 400, body: { message: error.message } };
+        }
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
-      }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.completeSession)
-  async completeSession(
-    @TsRestRequest() { params, body }: RequestShapes['completeSession']
-  ) {
-    try {
-      const completedSession = await this.sessionService.completeSession(
-        params.id,
-        body.completedDate
-      );
-      return { status: 200 as const, body: completedSession };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.completeSession)
+  async completeSession() {
+    return tsRestHandler(c.completeSession, async ({ params, body }) => {
+      try {
+        const completedSession = await this.sessionService.completeSession(
+          params.id,
+          body.completedDate
+        );
+        return { status: 200, body: completedSession };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.deleteSession)
-  async deleteSession(
-    @TsRestRequest() { params }: RequestShapes['deleteSession']
-  ) {
-    try {
-      await this.sessionService.deleteSession(params.id);
-      return {
-        status: 200 as const,
-        body: { message: 'Session deleted successfully' },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return { status: 404 as const, body: { message: error.message } };
+  @TsRestHandler(c.deleteSession)
+  async deleteSession() {
+    return tsRestHandler(c.deleteSession, async ({ params }) => {
+      try {
+        await this.sessionService.deleteSession(params.id);
+        return {
+          status: 200,
+          body: { message: 'Session deleted successfully' },
+        };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { status: 404, body: { message: error.message } };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 }

--- a/apps/api/src/modules/workout-category/workout-category.controller.ts
+++ b/apps/api/src/modules/workout-category/workout-category.controller.ts
@@ -4,145 +4,139 @@ import {
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import { NestRequestShapes, TsRest, TsRestRequest } from '@ts-rest/nest';
-import { NestControllerInterface } from '@ts-rest/nest';
-import { nestControllerContract } from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { WorkoutCategoryService } from './workout-category.service';
 
-const c = nestControllerContract(workoutCategoryContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = workoutCategoryContract;
 
 @Controller()
-export class WorkoutCategoryController
-  implements NestControllerInterface<typeof c>
-{
+export class WorkoutCategoryController {
   constructor(
     private readonly workoutCategoryService: WorkoutCategoryService
   ) {}
 
-  @TsRest(c.getWorkoutCategories)
-  async getWorkoutCategories(
-    @TsRestRequest() request: RequestShapes['getWorkoutCategories']
-  ) {
-    try {
-      const workoutCategories =
-        await this.workoutCategoryService.getWorkoutCategories();
-      return {
-        status: 200 as const,
-        body: workoutCategories,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getWorkoutCategories)
+  async getWorkoutCategories() {
+    return tsRestHandler(c.getWorkoutCategories, async () => {
+      try {
+        const workoutCategories =
+          await this.workoutCategoryService.getWorkoutCategories();
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workoutCategories,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.getWorkoutCategory)
-  async getWorkoutCategory(
-    @TsRestRequest()
-    { params }: RequestShapes['getWorkoutCategory']
-  ) {
-    try {
-      const workoutCategory =
-        await this.workoutCategoryService.getWorkoutCategory(params.id);
-      return {
-        status: 200 as const,
-        body: workoutCategory,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
+  @TsRestHandler(c.getWorkoutCategory)
+  async getWorkoutCategory() {
+    return tsRestHandler(c.getWorkoutCategory, async ({ params }) => {
+      try {
+        const workoutCategory =
+          await this.workoutCategoryService.getWorkoutCategory(params.id);
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workoutCategory,
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.createWorkoutCategory)
-  async createWorkoutCategory(
-    @TsRestRequest() { body }: RequestShapes['createWorkoutCategory']
-  ) {
-    try {
-      const workoutCategory =
-        await this.workoutCategoryService.createWorkoutCategory(body);
-      return {
-        status: 201 as const,
-        body: workoutCategory,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createWorkoutCategory)
+  async createWorkoutCategory() {
+    return tsRestHandler(c.createWorkoutCategory, async ({ body }) => {
+      try {
+        const workoutCategory =
+          await this.workoutCategoryService.createWorkoutCategory(body);
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 201,
+          body: workoutCategory,
         };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.updateWorkoutCategory)
-  async updateWorkoutCategory(
-    @TsRestRequest() { params, body }: RequestShapes['updateWorkoutCategory']
-  ) {
-    try {
-      const workoutCategory =
-        await this.workoutCategoryService.updateWorkoutCategory(
-          params.id,
-          body
-        );
-      return {
-        status: 200 as const,
-        body: workoutCategory,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.updateWorkoutCategory)
+  async updateWorkoutCategory() {
+    return tsRestHandler(c.updateWorkoutCategory, async ({ params, body }) => {
+      try {
+        const workoutCategory =
+          await this.workoutCategoryService.updateWorkoutCategory(
+            params.id,
+            body
+          );
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workoutCategory,
         };
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
-  @TsRest(c.deleteWorkoutCategory)
-  async deleteWorkoutCategory(
-    @TsRestRequest() { params }: RequestShapes['deleteWorkoutCategory']
-  ) {
-    try {
-      await this.workoutCategoryService.deleteWorkoutCategory(params.id);
+  @TsRestHandler(c.deleteWorkoutCategory)
+  async deleteWorkoutCategory() {
+    return tsRestHandler(c.deleteWorkoutCategory, async ({ params }) => {
+      try {
+        await this.workoutCategoryService.deleteWorkoutCategory(params.id);
 
-      return {
-        status: 200 as const,
-        body: {
-          message: 'Workout category deleted successfully',
-        },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
+          status: 200,
           body: {
-            message: error.message,
+            message: 'Workout category deleted successfully',
           },
         };
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 }

--- a/apps/api/src/modules/workout/workout.controller.ts
+++ b/apps/api/src/modules/workout/workout.controller.ts
@@ -1,142 +1,144 @@
-import { NestRequestShapes, TsRest, TsRestRequest } from '@ts-rest/nest';
-
-import { nestControllerContract } from '@ts-rest/nest';
-
 import { workoutContract } from '@dropit/contract';
 import {
   BadRequestException,
   Controller,
   NotFoundException,
 } from '@nestjs/common';
-import { NestControllerInterface } from '@ts-rest/nest';
+import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { WorkoutService } from './workout.service';
 
-const c = nestControllerContract(workoutContract);
-type RequestShapes = NestRequestShapes<typeof c>;
+const c = workoutContract;
 
 @Controller()
-export class WorkoutController implements NestControllerInterface<typeof c> {
+export class WorkoutController {
   constructor(private readonly workoutService: WorkoutService) {}
 
-  @TsRest(c.getWorkouts)
-  async getWorkouts(@TsRestRequest() request: RequestShapes['getWorkouts']) {
-    try {
-      const workouts = await this.workoutService.getWorkouts();
+  @TsRestHandler(c.getWorkouts)
+  async getWorkouts() {
+    return tsRestHandler(c.getWorkouts, async () => {
+      try {
+        const workouts = await this.workoutService.getWorkouts();
 
-      return {
-        status: 200 as const,
-        body: workouts,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workouts,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.getWorkout)
-  async getWorkout(@TsRestRequest() { params }: RequestShapes['getWorkout']) {
-    try {
-      const workout = await this.workoutService.getWorkout(params.id);
+  @TsRestHandler(c.getWorkout)
+  async getWorkout() {
+    return tsRestHandler(c.getWorkout, async ({ params }) => {
+      try {
+        const workout = await this.workoutService.getWorkout(params.id);
 
-      return {
-        status: 200 as const,
-        body: workout,
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workout,
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.createWorkout)
-  async createWorkout(
-    @TsRestRequest() { body }: RequestShapes['createWorkout']
-  ) {
-    try {
-      const workout = await this.workoutService.createWorkout(body);
-      return {
-        status: 201 as const,
-        body: workout,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
+  @TsRestHandler(c.createWorkout)
+  async createWorkout() {
+    return tsRestHandler(c.createWorkout, async ({ body }) => {
+      try {
+        const workout = await this.workoutService.createWorkout(body);
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 201,
+          body: workout,
         };
-      }
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.updateWorkout)
-  async updateWorkout(
-    @TsRestRequest() { params, body }: RequestShapes['updateWorkout']
-  ) {
-    try {
-      const workout = await this.workoutService.updateWorkout(params.id, body);
+  @TsRestHandler(c.updateWorkout)
+  async updateWorkout() {
+    return tsRestHandler(c.updateWorkout, async ({ params, body }) => {
+      try {
+        const workout = await this.workoutService.updateWorkout(
+          params.id,
+          body
+        );
 
-      return {
-        status: 200 as const,
-        body: workout,
-      };
-    } catch (error) {
-      if (error instanceof BadRequestException) {
         return {
-          status: 400 as const,
-          body: {
-            message: error.message,
-          },
+          status: 200,
+          body: workout,
         };
-      }
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          return {
+            status: 400,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 
-  @TsRest(c.deleteWorkout)
-  async deleteWorkout(
-    @TsRestRequest() { params }: RequestShapes['deleteWorkout']
-  ) {
-    try {
-      await this.workoutService.deleteWorkout(params.id);
+  @TsRestHandler(c.deleteWorkout)
+  async deleteWorkout() {
+    return tsRestHandler(c.deleteWorkout, async ({ params }) => {
+      try {
+        await this.workoutService.deleteWorkout(params.id);
 
-      return {
-        status: 200 as const,
-        body: {
-          message: 'Workout deleted successfully',
-        },
-      };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
         return {
-          status: 404 as const,
+          status: 200,
           body: {
-            message: error.message,
+            message: 'Workout deleted successfully',
           },
         };
-      }
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return {
+            status: 404,
+            body: {
+              message: error.message,
+            },
+          };
+        }
 
-      throw error;
-    }
+        throw error;
+      }
+    });
   }
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,5 +7,9 @@
     "target": "ES2021",
     "outDir": "./dist",
     "incremental": true,
+
+    // ⬇️ important : on coupe la génération de .d.ts ici pour éviter les erreurs de typage ts-rest
+    "declaration": false,
+    "declarationMap": false
   },
 }


### PR DESCRIPTION
- Replace @TsRest with @TsRestHandler
- Replace parameter injection via @TsRestRequest() with handler functions
- Use tsRestHandler to wrap handler implementation
- Remove nestControllerContract in favor of direct contract usage
- Remove NestControllerInterface implementation
- Remove type assertions with as const

This commit refactors all controllers to use the new ts-rest API pattern, moving away from the deprecated approach.