### PR TITLE
♻️ refactor: rename athlete avatar field to image

### DIFF
--- a/apps/api/src/modules/members/athlete/athlete.presenter.ts
+++ b/apps/api/src/modules/members/athlete/athlete.presenter.ts
@@ -9,7 +9,7 @@ export const AthletePresenter = {
       lastName: athlete.lastName,
       birthday: new Date(athlete.birthday),
       email: athlete.email ?? '',
-      avatar: athlete.avatar ?? '',
+      image: athlete.image ?? '',
       country: athlete.country,
       club: athlete.club ?? '',
       metrics: athlete.weight ? { weight: athlete.weight } : undefined,

--- a/apps/api/src/modules/members/athlete/athlete.repository.ts
+++ b/apps/api/src/modules/members/athlete/athlete.repository.ts
@@ -13,7 +13,7 @@ export type AthleteBasics = Pick<
 export type AthleteDetails = AthleteBasics & {
   club: string;
   email: string;
-  avatar: string;
+  image: string;
   weight: number;
   level: string;
   sex_category: string;
@@ -43,7 +43,7 @@ export class AthleteRepository extends EntityRepository<Athlete> {
       'a.country',
       'c.name AS club',
       'u.email',
-      'u.avatar',
+      'u.image',
       'pm.weight',
       'cs.level',
       'cs.sexCategory',

--- a/apps/web/src/features/athletes/athlete-detail.tsx
+++ b/apps/web/src/features/athletes/athlete-detail.tsx
@@ -88,7 +88,7 @@ export function AthleteDetail({
       <div className="w-full flex flex-col md:flex-row items-center md:items-start gap-6 mb-8">
         <Avatar className="h-28 w-28 border-2 border-primary">
           <AvatarImage
-            src={athlete.avatar}
+            src={athlete.image}
             alt={`${athlete.firstName} ${athlete.lastName}`}
           />
           <AvatarFallback className="text-xl bg-primary/10">

--- a/apps/web/src/features/athletes/columns.tsx
+++ b/apps/web/src/features/athletes/columns.tsx
@@ -41,12 +41,12 @@ export const columns: ColumnDef<AthleteDto>[] = [
       const firstName = row.original.firstName;
       const lastName = row.original.lastName;
       const email = row.original.email;
-      const avatar = row.original.avatar;
+      const image = row.original.image;
 
       return (
         <div className="flex items-center gap-3">
           <Avatar>
-            <AvatarImage src={avatar} />
+            <AvatarImage src={image} />
             <AvatarFallback>{`${firstName[0]}${lastName[0]}`}</AvatarFallback>
           </Avatar>
           <div className="flex flex-col">

--- a/packages/schemas/src/athlete.schema.ts
+++ b/packages/schemas/src/athlete.schema.ts
@@ -18,7 +18,7 @@ export const athleteSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   email: z.string().email(),
-  avatar: z.string().optional(),
+  image: z.string().optional(),
   birthday: z.date(),
   country: z.string().optional(),
   club: z.string().optional(),


### PR DESCRIPTION
- Update athlete presenter to use 'image' instead of 'avatar'
- Modify athlete repository types and queries to use 'image' field
- Update frontend athlete detail and columns components
- Update athlete schema validation to use 'image' field

Required due to Better Auth migration schema changes.