### PR TITLE
✨ feat(organization): Initial setup for organization creation flow

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { DbModule } from './modules/core/db/db.module';
 import { EmailModule } from './modules/core/email/email.module';
 import { AthleteModule } from './modules/members/athlete/athlete.module';
 import { AuthModule } from './modules/members/auth/auth.module';
+import { OrganizationModule } from './modules/members/organization/organization.module';
 import { AthleteSessionModule } from './modules/performance/athlete-session/athlete-session.module';
 import { PersonalRecordModule } from './modules/performance/personal-record/personal-record.module';
 import { SessionModule } from './modules/performance/session/session.module';
@@ -19,6 +20,7 @@ import { WorkoutModule } from './modules/training/workout/workout.module';
     DbModule,
     AuthModule.forRootAsync(),
     AthleteModule,
+    OrganizationModule,
     AthleteSessionModule,
     ExerciseModule,
     ExerciseCategoryModule,

--- a/apps/api/src/config/better-auth.config.ts
+++ b/apps/api/src/config/better-auth.config.ts
@@ -4,6 +4,7 @@ import { openAPI } from 'better-auth/plugins';
 import { Pool } from 'pg';
 import { config } from './env.config';
 import { UserRole } from '../modules/members/auth/auth.entity';
+import { organization } from 'better-auth/plugins/organization';
 
 interface BetterAuthOptionsDynamic {
   sendResetPassword?: (
@@ -80,7 +81,7 @@ export function createAuthConfig(options?: BetterAuthOptionsDynamic) {
         }
       }),
     },
-    plugins: [openAPI()],
+    plugins: [openAPI(), organization()],
   });
 }
 

--- a/apps/api/src/modules/members/auth/auth.entity.ts
+++ b/apps/api/src/modules/members/auth/auth.entity.ts
@@ -68,6 +68,9 @@ export class Session {
   @Property({ fieldName: 'userAgent', nullable: true })
   userAgent?: string
 
+  @Property({ fieldName: 'activeOrganizationId', nullable: true })
+  activeOrganizationId?: string
+
   @ManyToOne(() => User, { fieldName: 'userId' })
   user!: User
 }

--- a/apps/api/src/modules/members/organization/organization.entity.ts
+++ b/apps/api/src/modules/members/organization/organization.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  Collection,
+} from '@mikro-orm/core';
+import { User } from '../auth/auth.entity';
+
+/**
+ * Entités pour le plugin organization de Better Auth
+ */
+
+@Entity({ tableName: 'organization' })
+export class Organization {
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  slug?: string;
+
+  @Property({ nullable: true })
+  logo?: string;
+
+  @Property({ nullable: true })
+  metadata?: string;
+
+  @Property({ fieldName: 'createdAt' })
+  createdAt: Date = new Date();
+
+  @OneToMany(() => Member, (member) => member.organization)
+  members = new Collection<Member>(this);
+
+  @OneToMany(() => Invitation, (invitation) => invitation.organization)
+  invitations = new Collection<Invitation>(this);
+}
+
+@Entity({ tableName: 'member' })
+export class Member {
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne(() => User, { fieldName: 'userId' })
+  user!: User;
+
+  @ManyToOne(() => Organization, { fieldName: 'organizationId' })
+  organization!: Organization;
+
+  @Property({ default: 'member' })
+  role = 'member';
+
+  @Property({ fieldName: 'createdAt' })
+  createdAt: Date = new Date();
+}
+
+@Entity({ tableName: 'invitation' })
+export class Invitation {
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @Property()
+  email!: string;
+
+  @ManyToOne(() => User, { fieldName: 'inviterId' })
+  inviter!: User;
+
+  @ManyToOne(() => Organization, { fieldName: 'organizationId' })
+  organization!: Organization;
+
+  @Property({ default: 'member' })
+  role = 'member';
+
+  @Property({ default: 'pending' })
+  status = 'pending';
+
+  @Property({ fieldName: 'expiresAt' })
+  expiresAt!: Date;
+
+  @Property({ fieldName: 'createdAt' })
+  createdAt: Date = new Date();
+} 

--- a/apps/api/src/modules/members/organization/organization.module.ts
+++ b/apps/api/src/modules/members/organization/organization.module.ts
@@ -1,0 +1,9 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Module } from '@nestjs/common';
+import { Organization, Member, Invitation } from './organization.entity';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([Organization, Member, Invitation])],
+  exports: [MikroOrmModule.forFeature([Organization, Member, Invitation])],
+})
+export class OrganizationModule {} 

--- a/apps/web/src/features/organization/organization-creation-form.tsx
+++ b/apps/web/src/features/organization/organization-creation-form.tsx
@@ -1,0 +1,131 @@
+import { authClient } from '@/lib/auth-client';
+import { Button } from '@/shared/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
+import { Input } from '@/shared/components/ui/input';
+import { Label } from '@/shared/components/ui/label';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { useToast } from '@/shared/hooks/use-toast';
+import { useTranslation } from '@dropit/i18n';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+
+const createOrganizationSchema = z.object({
+  name: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
+  slug: z.string().min(2, 'Le slug doit contenir au moins 2 caractères'),
+  description: z.string().optional(),
+});
+
+type CreateOrganizationData = z.infer<typeof createOrganizationSchema>;
+
+export function OrganizationCreationForm() {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+
+  const form = useForm<CreateOrganizationData>({
+    resolver: zodResolver(createOrganizationSchema),
+    defaultValues: {
+      name: '',
+      slug: '',
+      description: '',
+    },
+  });
+
+  const createOrganizationMutation = useMutation({
+    mutationFn: async (data: CreateOrganizationData) => {
+      const result = await authClient.organization.create(data);
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+      return result;
+    },
+    onSuccess: () => {
+      toast({
+        title: t('organization.create.success.title'),
+        description: t('organization.create.success.description'),
+      });
+      navigate({ to: '/dashboard' });
+    },
+    onError: (error) => {
+      toast({
+        title: t('organization.create.error.title'),
+        description: error.message || t('organization.create.error.description'),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const onSubmit = (data: CreateOrganizationData) => {
+    createOrganizationMutation.mutate(data);
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>{t('organization.create.title')}</CardTitle>
+        <CardDescription>
+          {t('organization.create.description')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">{t('organization.fields.name')}</Label>
+            <Input
+              id="name"
+              {...form.register('name')}
+              placeholder={t('organization.fields.name_placeholder')}
+            />
+            {form.formState.errors.name && (
+              <p className="text-sm text-red-600">
+                {form.formState.errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="slug">{t('organization.fields.slug')}</Label>
+            <Input
+              id="slug"
+              {...form.register('slug')}
+              placeholder={t('organization.fields.slug_placeholder')}
+            />
+            {form.formState.errors.slug && (
+              <p className="text-sm text-red-600">
+                {form.formState.errors.slug.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">{t('organization.fields.description')}</Label>
+            <Textarea
+              id="description"
+              {...form.register('description')}
+              placeholder={t('organization.fields.description_placeholder')}
+              rows={3}
+            />
+            {form.formState.errors.description && (
+              <p className="text-sm text-red-600">
+                {form.formState.errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={createOrganizationMutation.isPending}
+          >
+            {createOrganizationMutation.isPending
+              ? t('common.loading')
+              : t('organization.create.button')}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,9 @@
 import { createAuthClient } from 'better-auth/react';
+import { organizationClient } from 'better-auth/client/plugins';
 
 const authClient = createAuthClient({
   baseURL: 'http://localhost:3000',
+  plugins: [organizationClient()],
 });
 
 export { authClient };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as rootRoute } from './routes/__root'
 import { Route as homeImport } from './routes/__home'
 import { Route as authImport } from './routes/__auth'
 import { Route as IndexImport } from './routes/index'
+import { Route as homeSetupOrganizationImport } from './routes/__home.setup-organization'
 import { Route as homeProgramsImport } from './routes/__home.programs'
 import { Route as homePlanningImport } from './routes/__home.planning'
 import { Route as homeDashboardImport } from './routes/__home.dashboard'
@@ -83,6 +84,12 @@ const authLoginLazyRoute = authLoginLazyImport
     getParentRoute: () => authRoute,
   } as any)
   .lazy(() => import('./routes/__auth.login.lazy').then((d) => d.Route))
+
+const homeSetupOrganizationRoute = homeSetupOrganizationImport.update({
+  id: '/setup-organization',
+  path: '/setup-organization',
+  getParentRoute: () => homeRoute,
+} as any)
 
 const homeProgramsRoute = homeProgramsImport.update({
   id: '/programs',
@@ -204,6 +211,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof homeProgramsImport
       parentRoute: typeof homeImport
     }
+    '/__home/setup-organization': {
+      id: '/__home/setup-organization'
+      path: '/setup-organization'
+      fullPath: '/setup-organization'
+      preLoaderRoute: typeof homeSetupOrganizationImport
+      parentRoute: typeof homeImport
+    }
     '/__auth/login': {
       id: '/__auth/login'
       path: '/login'
@@ -322,6 +336,7 @@ interface homeRouteChildren {
   homeDashboardRoute: typeof homeDashboardRoute
   homePlanningRoute: typeof homePlanningRoute
   homeProgramsRoute: typeof homeProgramsRouteWithChildren
+  homeSetupOrganizationRoute: typeof homeSetupOrganizationRoute
   homeWorkoutsWorkoutIdRoute: typeof homeWorkoutsWorkoutIdRoute
 }
 
@@ -331,6 +346,7 @@ const homeRouteChildren: homeRouteChildren = {
   homeDashboardRoute: homeDashboardRoute,
   homePlanningRoute: homePlanningRoute,
   homeProgramsRoute: homeProgramsRouteWithChildren,
+  homeSetupOrganizationRoute: homeSetupOrganizationRoute,
   homeWorkoutsWorkoutIdRoute: homeWorkoutsWorkoutIdRoute,
 }
 
@@ -344,6 +360,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof homeDashboardRoute
   '/planning': typeof homePlanningRoute
   '/programs': typeof homeProgramsRouteWithChildren
+  '/setup-organization': typeof homeSetupOrganizationRoute
   '/login': typeof authLoginLazyRoute
   '/privacy': typeof authPrivacyLazyRoute
   '/signup': typeof authSignupLazyRoute
@@ -363,6 +380,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof homeDashboardRoute
   '/planning': typeof homePlanningRoute
   '/programs': typeof homeProgramsRouteWithChildren
+  '/setup-organization': typeof homeSetupOrganizationRoute
   '/login': typeof authLoginLazyRoute
   '/privacy': typeof authPrivacyLazyRoute
   '/signup': typeof authSignupLazyRoute
@@ -384,6 +402,7 @@ export interface FileRoutesById {
   '/__home/dashboard': typeof homeDashboardRoute
   '/__home/planning': typeof homePlanningRoute
   '/__home/programs': typeof homeProgramsRouteWithChildren
+  '/__home/setup-organization': typeof homeSetupOrganizationRoute
   '/__auth/login': typeof authLoginLazyRoute
   '/__auth/privacy': typeof authPrivacyLazyRoute
   '/__auth/signup': typeof authSignupLazyRoute
@@ -405,6 +424,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/planning'
     | '/programs'
+    | '/setup-organization'
     | '/login'
     | '/privacy'
     | '/signup'
@@ -423,6 +443,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/planning'
     | '/programs'
+    | '/setup-organization'
     | '/login'
     | '/privacy'
     | '/signup'
@@ -442,6 +463,7 @@ export interface FileRouteTypes {
     | '/__home/dashboard'
     | '/__home/planning'
     | '/__home/programs'
+    | '/__home/setup-organization'
     | '/__auth/login'
     | '/__auth/privacy'
     | '/__auth/signup'
@@ -501,6 +523,7 @@ export const routeTree = rootRoute
         "/__home/dashboard",
         "/__home/planning",
         "/__home/programs",
+        "/__home/setup-organization",
         "/__home/workouts/$workoutId"
       ]
     },
@@ -531,6 +554,10 @@ export const routeTree = rootRoute
         "/__home/programs/exercises",
         "/__home/programs/workouts"
       ]
+    },
+    "/__home/setup-organization": {
+      "filePath": "__home.setup-organization.tsx",
+      "parent": "/__home"
     },
     "/__auth/login": {
       "filePath": "__auth.login.lazy.tsx",

--- a/apps/web/src/routes/__home.setup-organization.tsx
+++ b/apps/web/src/routes/__home.setup-organization.tsx
@@ -1,0 +1,56 @@
+import { authClient } from '@/lib/auth-client';
+import { useTranslation } from '@dropit/i18n';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { OrganizationCreationForm } from '../features/organization/organization-creation-form';
+
+export const Route = createFileRoute('/__home/setup-organization')({
+  component: SetupOrganizationPage,
+});
+
+function SetupOrganizationPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { data: session, isPending } = authClient.useSession();
+
+  useEffect(() => {
+    if (!isPending) {
+      if (!session) {
+        navigate({ to: '/login' });
+        return;
+      }
+      
+      // Vérifier si l'utilisateur est un coach
+      // Pour l'instant, on va simplifier et laisser passer
+      // TODO: Implémenter la vérification du rôle quand les types seront corrects
+    }
+  }, [session, isPending, navigate]);
+
+  if (isPending) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div>Loading...</div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+  
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900">
+            {t('organization.setup.title')}
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            {t('organization.setup.description')}
+          </p>
+        </div>
+        <OrganizationCreationForm />
+      </div>
+    </div>
+  );
+} 

--- a/apps/web/src/routes/__home.tsx
+++ b/apps/web/src/routes/__home.tsx
@@ -20,7 +20,20 @@ function HomeLayout() {
   useEffect(() => {
     if (!isPending && !session) {
       navigate({ to: '/login' });
+      return;
     }
+
+    // TODO: Implémenter la logique pour vérifier si l'utilisateur est un coach
+    // et s'il a une organisation. Pour l'instant, on laisse passer.
+    // 
+    // if (session?.user?.role === 'coach') {
+    //   // Vérifier s'il a une organisation
+    //   const hasOrganization = await checkUserOrganization(session.user.id);
+    //   if (!hasOrganization) {
+    //     navigate({ to: '/setup-organization' });
+    //     return;
+    //   }
+    // }
   }, [isPending, session, navigate]);
 
   if (isPending) {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -5,6 +5,8 @@ export const Route = createFileRoute('/')({
   beforeLoad: async () => {
     const session = await authClient.getSession();
     if (session) {
+      // TODO: Vérifier si l'utilisateur est un coach et s'il a une organisation
+      // Pour l'instant, rediriger vers le dashboard
       throw redirect({
         to: '/dashboard',
       });

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -100,5 +100,32 @@
       "columns": "Columns",
       "selected_rows": "{{count}} of {{total}} column(s) selected."
     }
+  },
+  "organization": {
+    "setup": {
+      "title": "Create Your Organization",
+      "description": "Set up your coaching organization to start managing athletes and programs."
+    },
+    "create": {
+      "title": "Create Organization",
+      "description": "Add a new organization to your account.",
+      "button": "Create Organization",
+      "success": {
+        "title": "Organization Created",
+        "description": "Your organization has been created successfully."
+      },
+      "error": {
+        "title": "Creation Failed",
+        "description": "Failed to create organization. Please try again."
+      }
+    },
+    "fields": {
+      "name": "Organization Name",
+      "name_placeholder": "Enter organization name",
+      "slug": "Slug",
+      "slug_placeholder": "Enter organization slug",
+      "description": "Description",
+      "description_placeholder": "Enter organization description"
+    }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -100,5 +100,32 @@
       "columns": "Colonnes",
       "selected_rows": "{{count}} sur {{total}} ligne(s) sélectionnée(s)"
     }
+  },
+  "organization": {
+    "setup": {
+      "title": "Créez votre organisation",
+      "description": "Configurez votre organisation de coaching pour commencer à gérer vos athlètes et vos programmes."
+    },
+    "create": {
+      "title": "Créer une organisation",
+      "description": "Ajoutez une nouvelle organisation à votre compte.",
+      "button": "Créer l'organisation",
+      "success": {
+        "title": "Organisation créée",
+        "description": "Votre organisation a été créée avec succès."
+      },
+      "error": {
+        "title": "Échec de la création",
+        "description": "La création de l'organisation a échoué. Veuillez réessayer."
+      }
+    },
+    "fields": {
+      "name": "Nom de l'organisation",
+      "name_placeholder": "Entrez le nom de l'organisation",
+      "slug": "Identifiant URL",
+      "slug_placeholder": "Ex: mon-organisation-de-coaching",
+      "description": "Description",
+      "description_placeholder": "Entrez la description de l'organisation"
+    }
   }
 }


### PR DESCRIPTION
This commit introduces the foundational feature for organization management, integrating the Better Auth 'organization' plugin. It sets up the backend entities, API configuration, and the frontend flow for a user (typically a coach) to create their first organization after signing up.

Key changes:

Backend:
- Adds `Organization`, `Member`, and `Invitation` MikroORM entities to support the plugin's database schema.
- Creates a dedicated `OrganizationModule` to encapsulate this logic.
- Updates the `Session` entity with `activeOrganizationId` for future context switching.
- Refactors `AuthService` to use a centralized `createAuthConfig`, ensuring plugins are loaded correctly and improving code structure.

Frontend:
- Implements a new route `/setup-organization` for users who need to create an organization.
- Adds the `OrganizationCreationForm` component with validation for the creation process.
- Configures `authClient` with `organizationClient` to enable frontend API interactions.
- Adds placeholder logic in `__home.tsx` and `index.tsx` for future redirection based on organization membership.

I18n:
- Adds translations for the new feature in both English and French (`common.json`).