### PR TITLE
✨ feat: add permissions to athlete controllers and refactor to clean …

### DIFF
--- a/apps/api/src/modules/members/athlete/application/ports/athlete-read.repository.ts
+++ b/apps/api/src/modules/members/athlete/application/ports/athlete-read.repository.ts
@@ -19,6 +19,6 @@ export type AthleteDetails = AthleteBasics & {
 };
 
 export interface AthleteReadRepository {
-    findOneWithDetails(id: string): Promise<AthleteDetails | null>;
-    findAllWithDetails(): Promise<AthleteDetails[]>;
+    findOneWithDetails(athleteId: string): Promise<AthleteDetails | null>;
+    findAllWithDetails(athleteUserIds: string[]): Promise<AthleteDetails[]>;
 }

--- a/apps/api/src/modules/members/athlete/application/ports/athlete-read.repository.ts
+++ b/apps/api/src/modules/members/athlete/application/ports/athlete-read.repository.ts
@@ -19,6 +19,6 @@ export type AthleteDetails = AthleteBasics & {
 };
 
 export interface AthleteReadRepository {
-    findOneWithDetails(athleteId: string): Promise<AthleteDetails | null>;
-    findAllWithDetails(athleteUserIds: string[]): Promise<AthleteDetails[]>;
+  findOneWithDetails(athleteId: string): Promise<AthleteDetails | null>;
+  findAllWithDetails(athleteUserIds: string[]): Promise<AthleteDetails[]>;
 }

--- a/apps/api/src/modules/members/athlete/application/use-cases/delete-athlete.use-case.ts
+++ b/apps/api/src/modules/members/athlete/application/use-cases/delete-athlete.use-case.ts
@@ -1,20 +1,41 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ATHLETE_WRITE_REPO, AthleteWriteRepository } from '../ports/athlete-write.repository';
+import { UserService } from '../../../auth/user.service';
 
 @Injectable()
 export class DeleteAthleteUseCase {
   constructor(
     @Inject(ATHLETE_WRITE_REPO)
-    private readonly athleteWriteRepository: AthleteWriteRepository
+    private readonly athleteWriteRepository: AthleteWriteRepository,
+    private readonly userService: UserService
   ) {}
 
-  async execute(id: string): Promise<void> {
-    const athlete = await this.athleteWriteRepository.ofId(id);
+  async execute(idAthlete: string, userId: string): Promise<void> {
+
+    //1. Get User
+    const user = await this.userService.getUserById(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    //2. Get Athlete
+    const athlete = await this.athleteWriteRepository.ofId(idAthlete);
 
     if (!athlete) {
       throw new NotFoundException('Athlete not found');
     }
-    
+
+    //3. Check if Athlete has a user  
+    if (!athlete.user) {
+      throw new NotFoundException('Athlete has no user');
+    }
+
+    //4. Check if Athlete belongs to User
+    if (athlete.user.id !== userId) {
+      throw new ForbiddenException('Athlete does not belong to User');
+    }
+
+    //5. Delete Athlete
     await this.athleteWriteRepository.remove(athlete);
   }
 }

--- a/apps/api/src/modules/members/athlete/application/use-cases/get-athlete.use-case.ts
+++ b/apps/api/src/modules/members/athlete/application/use-cases/get-athlete.use-case.ts
@@ -2,19 +2,30 @@ import { AthleteDetailsDto } from '@dropit/schemas';
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { AthletePresenter } from '../../interface/presenter/athlete.presenter';
 import { ATHLETE_READ_REPO, AthleteReadRepository } from '../ports/athlete-read.repository';
+import { OrganizationService } from '../../../organization/organization.service';
 
 @Injectable()
 export class GetAthleteUseCase {
   constructor(
     @Inject(ATHLETE_READ_REPO)
-    private readonly athleteReadRepository: AthleteReadRepository
+    private readonly athleteReadRepository: AthleteReadRepository,
+    private readonly organizationService: OrganizationService
   ) {}
 
-  async execute(id: string): Promise<AthleteDetailsDto> {
-    const athlete = await this.athleteReadRepository.findOneWithDetails(id);
+  async execute(athleteId: string, organizationId: string): Promise<AthleteDetailsDto> {
+
+    //1. Validate organization
+    const organization = await this.organizationService.getOrganizationById(organizationId);
+
+    //2. check if athleteId is in organization
+    await this.organizationService.checkAthleteBelongsToOrganization(athleteId, organization.id);
+
+    //3. Get athlete from repository
+    const athlete = await this.athleteReadRepository.findOneWithDetails(athleteId);
     if (!athlete) {
       throw new NotFoundException('Athlete not found');
     }
+
     return AthletePresenter.toDto(athlete);
   }
 }

--- a/apps/api/src/modules/members/athlete/application/use-cases/get-athletes.use-case.ts
+++ b/apps/api/src/modules/members/athlete/application/use-cases/get-athletes.use-case.ts
@@ -2,19 +2,30 @@ import { AthleteDetailsDto } from '@dropit/schemas';
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { AthletePresenter } from '../../interface/presenter/athlete.presenter';
 import { ATHLETE_READ_REPO, AthleteReadRepository } from '../ports/athlete-read.repository';
+import { OrganizationService } from '../../../organization/organization.service';
 
 @Injectable()
 export class GetAthletesUseCase {
   constructor(
     @Inject(ATHLETE_READ_REPO)
-    private readonly athleteReadRepository: AthleteReadRepository
+    private readonly athleteReadRepository: AthleteReadRepository,
+    private readonly organizationService: OrganizationService
   ) {}
 
-  async execute(): Promise<AthleteDetailsDto[]> {
-    const athletes = await this.athleteReadRepository.findAllWithDetails();
+  async execute(organizationId: string): Promise<AthleteDetailsDto[]> {
+
+    //1. Validate organization
+    const organization = await this.organizationService.getOrganizationById(organizationId);
+
+    //2. Get athletes ids from organization
+    const athleteUserIds = await this.organizationService.getAthleteUserIds(organizationId);
+
+    //3. Get athletes from repository
+    const athletes = await this.athleteReadRepository.findAllWithDetails(athleteUserIds);
     if (!athletes) {
       throw new NotFoundException('Athletes not found');
     }
+    
     return AthletePresenter.toDtoList(athletes);
   }
 }

--- a/apps/api/src/modules/members/athlete/athlete.module.ts
+++ b/apps/api/src/modules/members/athlete/athlete.module.ts
@@ -21,6 +21,7 @@ import { DeleteAthleteUseCase } from './application/use-cases/delete-athlete.use
 import { GetAthleteUseCase } from './application/use-cases/get-athlete.use-case';
 import { GetAthletesUseCase } from './application/use-cases/get-athletes.use-case';
 import { UpdateAthleteUseCase } from './application/use-cases/update-athlete.use-case';
+import { OrganizationModule } from '../organization/organization.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { UpdateAthleteUseCase } from './application/use-cases/update-athlete.use
       entities: [Athlete, PersonalRecord],
     }),
     forwardRef(() => PersonalRecordModule),
+    forwardRef(() => OrganizationModule),
   ],
 
   controllers: [AthleteController],

--- a/apps/api/src/modules/members/auth/auth.module.ts
+++ b/apps/api/src/modules/members/auth/auth.module.ts
@@ -24,6 +24,7 @@ import { EmailModule } from '../../core/email/email.module';
 import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from './auth.decorator';
 import { AuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
+import { UserService } from './user.service';
 
 @Global()
 @Module({
@@ -31,12 +32,13 @@ import { AuthService } from './auth.service';
   providers: [
     AuthService, 
     AuthGuard,
+    UserService,
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
     },
   ],
-  exports: [AuthService, AuthGuard],
+  exports: [AuthService, AuthGuard, UserService],
 })
 export class AuthModule implements NestModule, OnModuleInit {
   constructor(

--- a/apps/api/src/modules/members/auth/user.service.ts
+++ b/apps/api/src/modules/members/auth/user.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/core';
+import { User } from './auth.entity';
+
+@Injectable()
+export class UserService {
+  constructor(private readonly em: EntityManager) {}
+
+  /**
+   * Récupère un utilisateur par son ID
+   * @param userId - ID de l'utilisateur
+   * @returns L'utilisateur
+   * @throws NotFoundException si l'utilisateur n'est pas trouvé
+   */
+  async getUserById(userId: string): Promise<User> {
+    const user = await this.em.findOne(User, { id: userId });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+    return user;
+  }
+
+  /**
+   * Récupère un utilisateur par son email
+   * @param email - Email de l'utilisateur
+   * @returns L'utilisateur ou null
+   */
+  async getUserByEmail(email: string): Promise<User | null> {
+    return this.em.findOne(User, { email });
+  }
+
+  /**
+   * Vérifie si un utilisateur existe
+   * @param userId - ID de l'utilisateur
+   * @returns true si l'utilisateur existe
+   */
+  async userExists(userId: string): Promise<boolean> {
+    const user = await this.em.findOne(User, { id: userId });
+    return !!user;
+  }
+
+  /**
+   * Met à jour un utilisateur
+   * @param userId - ID de l'utilisateur
+   * @param updateData - Données à mettre à jour
+   * @returns L'utilisateur mis à jour
+   */
+  async updateUser(userId: string, updateData: Partial<User>): Promise<User> {
+    const user = await this.getUserById(userId);
+    
+    Object.assign(user, updateData);
+    user.updatedAt = new Date();
+    
+    await this.em.persistAndFlush(user);
+    return user;
+  }
+
+  /**
+   * Supprime un utilisateur
+   * @param userId - ID de l'utilisateur
+   */
+  async deleteUser(userId: string): Promise<void> {
+    const user = await this.getUserById(userId);
+    await this.em.removeAndFlush(user);
+  }
+}

--- a/apps/api/src/modules/members/organization/organization.service.ts
+++ b/apps/api/src/modules/members/organization/organization.service.ts
@@ -100,4 +100,36 @@ export class OrganizationService {
     }
     return organization;
   }
+
+  /**
+   * Récupère les IDs des athlètes d'une organisation
+   * @param organizationId - ID de l'organisation
+   * @returns Array des IDs des athlètes
+  */
+  async getAthleteUserIds(organizationId: string): Promise<string[]> {
+  const athleteMembers = await this.em.find(Member, {
+    organization: { id: organizationId },
+    role: 'member'
+  });
+
+  return athleteMembers.map((member) => member.user.id);
+  }
+
+  /**
+   * Vérifie si un athlète appartient à une organisation
+   * @param athleteId - ID de l'athlète
+   * @param organizationId - ID de l'organisation
+   * @throws NotFoundException si l'athlète n'appartient pas à l'organisation
+  */
+  async checkAthleteBelongsToOrganization(athleteId: string, organizationId: string): Promise<void> {
+    const member = await this.em.findOne(Member, {
+      user: { id: athleteId },
+      organization: { id: organizationId },
+      role: 'member'
+    });
+    
+    if (!member) {
+      throw new NotFoundException(`Athlete with ID ${athleteId} does not belong to organization ${organizationId}`);
+    }
+  }
 } 

--- a/apps/api/src/modules/permissions/permissions.decorator.ts
+++ b/apps/api/src/modules/permissions/permissions.decorator.ts
@@ -10,3 +10,7 @@ import { SetMetadata } from "@nestjs/common";
  */
 export const RequirePermissions = (...permissions: string[]) => 
   SetMetadata('REQUIRED_PERMISSIONS', permissions);
+
+export const NO_ORGANIZATION = 'NO_ORGANIZATION';
+export const NoOrganization = () => 
+  SetMetadata(NO_ORGANIZATION, true);

--- a/apps/api/src/modules/permissions/permissions.guard.spec.ts
+++ b/apps/api/src/modules/permissions/permissions.guard.spec.ts
@@ -83,9 +83,36 @@ describe('PermissionsGuard', () => {
     expect(guard).toBeDefined();
   });
 
+  describe('No Organization Actions Tests', () => {
+    it('should allow access for actions without organization', async () => {
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(true) // NO_ORGANIZATION
+        .mockReturnValueOnce(['create']); // REQUIRED_PERMISSIONS
+
+      const result = await guard.canActivate(mockContext);
+      expect(result).toBe(true);
+    });
+
+    it('should allow access for athlete creation without organization', async () => {
+      const athleteContext = {
+        ...mockContext,
+        getClass: () => ({ name: 'AthleteController' }),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(true) // NO_ORGANIZATION
+        .mockReturnValueOnce(['create']); // REQUIRED_PERMISSIONS
+
+      const result = await guard.canActivate(athleteContext);
+      expect(result).toBe(true);
+    });
+  });
+
   describe('Permission Mapping Tests', () => {
     it('should correctly map member permissions for workout resource', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS (vérifié en premier)
+        .mockReturnValueOnce(false); // NO_ORGANIZATION (vérifié en second)
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(mockContext);
@@ -98,27 +125,31 @@ describe('PermissionsGuard', () => {
     });
 
     it('should correctly map admin permissions for workout resource', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['create']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['create']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       const adminMember = { ...mockMember, role: 'admin' };
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(adminMember);
 
       const result = await guard.canActivate(mockContext);
-
       expect(result).toBe(true);
     });
 
     it('should correctly map owner permissions for workout resource', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['delete']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['delete']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       const ownerMember = { ...mockMember, role: 'owner' };
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(ownerMember);
 
       const result = await guard.canActivate(mockContext);
-
       expect(result).toBe(true);
     });
 
     it('should handle unknown organization role', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       const unknownRoleMember = { ...mockMember, role: 'unknown' };
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(unknownRoleMember);
 
@@ -133,7 +164,9 @@ describe('PermissionsGuard', () => {
         getClass: () => ({ name: 'WorkoutController' }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(false) // NO_ORGANIZATION
+        .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(workoutContext);
@@ -146,7 +179,9 @@ describe('PermissionsGuard', () => {
         getClass: () => ({ name: 'ExerciseController' }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(false) // NO_ORGANIZATION
+        .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(exerciseContext);
@@ -159,7 +194,9 @@ describe('PermissionsGuard', () => {
         getClass: () => ({ name: 'ComplexController' }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(false) // NO_ORGANIZATION
+        .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(complexContext);
@@ -172,7 +209,9 @@ describe('PermissionsGuard', () => {
         getClass: () => ({ name: 'AthleteController' }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(false) // NO_ORGANIZATION
+        .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(athleteContext);
@@ -185,7 +224,9 @@ describe('PermissionsGuard', () => {
         getClass: () => ({ name: 'SessionController' }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(false) // NO_ORGANIZATION
+        .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(sessionContext);
@@ -196,7 +237,9 @@ describe('PermissionsGuard', () => {
   describe('Role-based Access Tests', () => {
     describe('Member Role Tests', () => {
       it('should allow member to read workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(false) // NO_ORGANIZATION
+          .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
         const result = await guard.canActivate(mockContext);
@@ -204,21 +247,27 @@ describe('PermissionsGuard', () => {
       });
 
       it('should deny member from creating workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['create']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['create']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
         await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
       });
 
       it('should deny member from updating workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['update']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['update']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
         await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
       });
 
       it('should deny member from deleting workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['delete']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['delete']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
         await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
@@ -230,19 +279,13 @@ describe('PermissionsGuard', () => {
           getClass: () => ({ name: 'PersonalRecordController' }),
         } as unknown as ExecutionContext;
 
-        jest.spyOn(reflector, 'get').mockReturnValue(['create']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(false) // NO_ORGANIZATION
+          .mockReturnValueOnce(['create']); // REQUIRED_PERMISSIONS
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
-        await expect(guard.canActivate(personalRecordContext)).resolves.toBe(true);
-      });
-
-      it('should document the current controller name transformation behavior', () => {
-        const controllerName = 'PersonalRecordController';
-        const resource = controllerName.replace('Controller', '').toLowerCase();
-        
-        expect(resource).toBe('personalrecord');
-        expect((member.statements as Record<string, string[]>).personalRecord).toBeDefined();
-        expect((member.statements as Record<string, string[]>).personalrecord).toBeUndefined();
+        const result = await guard.canActivate(personalRecordContext);
+        expect(result).toBe(true);
       });
     });
 
@@ -250,7 +293,9 @@ describe('PermissionsGuard', () => {
       const adminMember = { ...mockMember, role: 'admin' };
 
       it('should allow admin to read workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(false) // NO_ORGANIZATION
+          .mockReturnValueOnce(['read']); // REQUIRED_PERMISSIONS
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(adminMember);
 
         const result = await guard.canActivate(mockContext);
@@ -258,7 +303,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow admin to create workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['create']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(false) // NO_ORGANIZATION
+          .mockReturnValueOnce(['create']); // REQUIRED_PERMISSIONS
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(adminMember);
 
         const result = await guard.canActivate(mockContext);
@@ -266,7 +313,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow admin to update workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['update']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['update']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(adminMember);
 
         const result = await guard.canActivate(mockContext);
@@ -274,7 +323,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow admin to delete workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['delete']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['delete']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(adminMember);
 
         const result = await guard.canActivate(mockContext);
@@ -286,7 +337,9 @@ describe('PermissionsGuard', () => {
       const ownerMember = { ...mockMember, role: 'owner' };
 
       it('should allow owner to read workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(ownerMember);
 
         const result = await guard.canActivate(mockContext);
@@ -294,7 +347,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow owner to create workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['create']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['create']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(ownerMember);
 
         const result = await guard.canActivate(mockContext);
@@ -302,7 +357,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow owner to update workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['update']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['update']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(ownerMember);
 
         const result = await guard.canActivate(mockContext);
@@ -310,7 +367,9 @@ describe('PermissionsGuard', () => {
       });
 
       it('should allow owner to delete workouts', async () => {
-        jest.spyOn(reflector, 'get').mockReturnValue(['delete']);
+        jest.spyOn(reflector, 'get')
+          .mockReturnValueOnce(['delete']) // REQUIRED_PERMISSIONS
+          .mockReturnValueOnce(false); // NO_ORGANIZATION
         jest.spyOn(entityManager, 'findOne').mockResolvedValue(ownerMember);
 
         const result = await guard.canActivate(mockContext);
@@ -321,7 +380,9 @@ describe('PermissionsGuard', () => {
 
   describe('Multiple Permissions Tests', () => {
     it('should allow access if user has at least one required permission (OR logic)', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['read', 'create']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read', 'create']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(mockContext);
@@ -329,7 +390,9 @@ describe('PermissionsGuard', () => {
     });
 
     it('should deny access if user has none of the required permissions', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['create', 'update']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['create', 'update']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);
@@ -351,7 +414,9 @@ describe('PermissionsGuard', () => {
         switchToHttp: () => ({ getRequest: () => requestWithoutUser }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
 
       await expect(guard.canActivate(contextWithoutUser)).rejects.toThrow(
         new ForbiddenException('Permission check failed')
@@ -375,7 +440,9 @@ describe('PermissionsGuard', () => {
         switchToHttp: () => ({ getRequest: () => requestWithoutOrg }),
       } as unknown as ExecutionContext;
 
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
 
       await expect(guard.canActivate(contextWithoutOrg)).rejects.toThrow(
         new ForbiddenException('Permission check failed')
@@ -383,7 +450,9 @@ describe('PermissionsGuard', () => {
     });
 
     it('should throw error when user is not a member of the organization', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(null);
 
       await expect(guard.canActivate(mockContext)).rejects.toThrow(
@@ -394,7 +463,9 @@ describe('PermissionsGuard', () => {
 
   describe('No Required Permissions Tests', () => {
     it('should allow access when no permissions are required', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(undefined) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(mockContext);
@@ -402,7 +473,9 @@ describe('PermissionsGuard', () => {
     });
 
     it('should allow access when empty permissions array is required', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue([]);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce([]) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockResolvedValue(mockMember);
 
       const result = await guard.canActivate(mockContext);
@@ -412,7 +485,9 @@ describe('PermissionsGuard', () => {
 
   describe('Database Error Handling', () => {
     it('should handle database errors gracefully', async () => {
-      jest.spyOn(reflector, 'get').mockReturnValue(['read']);
+      jest.spyOn(reflector, 'get')
+        .mockReturnValueOnce(['read']) // REQUIRED_PERMISSIONS
+        .mockReturnValueOnce(false); // NO_ORGANIZATION
       jest.spyOn(entityManager, 'findOne').mockRejectedValue(new Error('Database connection failed'));
 
       await expect(guard.canActivate(mockContext)).rejects.toThrow(ForbiddenException);

--- a/apps/api/src/seeders/organization.seeder.ts
+++ b/apps/api/src/seeders/organization.seeder.ts
@@ -1,6 +1,6 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Organization, Member } from '../modules/members/organization/organization.entity';
-import { User, Session } from '../modules/members/auth/auth.entity';
+import { User } from '../modules/members/auth/auth.entity';
 
 export async function seedOrganizations(
   em: EntityManager

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -33,7 +33,7 @@ export const member = ac.newRole({
   workout: ["read"],
   exercise: ["read"],
   complex: ["read"],
-  athlete: ["read"],
+  athlete: ["read", "create", "update", "delete"],
   session: ["read"],
   personalRecord: ["read", "create"],
   trainingSession: ["read"],


### PR DESCRIPTION
…architecture

- Add permission decorators and guards to athlete controller endpoints
- Implement clean architecture pattern for athlete module with use cases and ports
- Extend athlete permissions to include create, update, and delete operations
- Add authentication decorators for user context in athlete operations
- Refactor athlete module structure with proper separation of concerns
- Update permissions package to support full CRUD operations on athletes