### PR TITLE
🐛 fix: update training session repositories and module configuration

### DIFF
--- a/apps/api/src/modules/performance/training-session/infrastructure/mikro-athlete-training-session.repository.ts
+++ b/apps/api/src/modules/performance/training-session/infrastructure/mikro-athlete-training-session.repository.ts
@@ -1,7 +1,9 @@
-import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { EntityManager, EntityRepository } from "@mikro-orm/core";
 import { AthleteTrainingSession } from "../domain/athlete-training-session.entity";
 import { AthleteTrainingSessionRepository } from "../application/ports/athlete-training-session.repository";
+import { Injectable } from "@nestjs/common";
 
+@Injectable()
 export class MikroAthleteTrainingSessionRepository extends EntityRepository<AthleteTrainingSession> implements AthleteTrainingSessionRepository {
   constructor(public readonly em: EntityManager) {
     super(em, AthleteTrainingSession);

--- a/apps/api/src/modules/performance/training-session/infrastructure/mikro-training-session.repository.ts
+++ b/apps/api/src/modules/performance/training-session/infrastructure/mikro-training-session.repository.ts
@@ -1,7 +1,9 @@
-import { EntityManager, EntityRepository } from "@mikro-orm/postgresql";
+import { EntityManager, EntityRepository } from "@mikro-orm/core";
 import { TrainingSession } from "../domain/training-session.entity";
 import { TrainingSessionRepository } from "../application/ports/training-session.repository";
+import { Injectable } from "@nestjs/common";
 
+@Injectable()
 export class MikroTrainingSessionRepository extends EntityRepository<TrainingSession> implements TrainingSessionRepository {
   constructor(public readonly em: EntityManager) {
     super(em, TrainingSession);

--- a/apps/api/src/modules/performance/training-session/training-session.module.ts
+++ b/apps/api/src/modules/performance/training-session/training-session.module.ts
@@ -1,15 +1,22 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
+
 import { Athlete } from '../../members/athlete/domain/athlete.entity';
+import { Workout } from '../../training/workout/workout.entity';
+import { TrainingSession } from './domain/training-session.entity';
+import { AthleteTrainingSession } from './domain/athlete-training-session.entity';
+
 import { AthleteModule } from '../../members/athlete/athlete.module';
 import { OrganizationModule } from '../../members/organization/organization.module';
-import { Workout } from '../../training/workout/workout.entity';
 import { WorkoutModule } from '../../training/workout/workout.module';
+
 import { TrainingSessionController } from './interface/training-session.controller';
-import { TrainingSession } from './domain/training-session.entity';
+
 import { TrainingSessionPresenter } from './interface/presenters/training-session.presenter';
 import { AthleteTrainingSessionPresenter } from './interface/presenters/athlete-training-session.presenter';
+
 import { TrainingSessionUseCase } from './application/use-cases/training-session.use-case';
+
 import { MikroTrainingSessionRepository } from './infrastructure/mikro-training-session.repository';
 import { MikroAthleteTrainingSessionRepository } from './infrastructure/mikro-athlete-training-session.repository';
 import { TRAINING_SESSION_REPO } from './application/ports/training-session.repository';
@@ -17,10 +24,13 @@ import { ATHLETE_TRAINING_SESSION_REPO } from './application/ports/athlete-train
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([TrainingSession, Athlete, Workout]),
+    MikroOrmModule.forFeature({
+      entities: [TrainingSession,AthleteTrainingSession, Athlete, Workout],
+    }),
     forwardRef(() => AthleteModule),
     forwardRef(() => OrganizationModule),
     forwardRef(() => WorkoutModule),
+
   ],
   controllers: [TrainingSessionController],
   providers: [
@@ -35,8 +45,7 @@ import { ATHLETE_TRAINING_SESSION_REPO } from './application/ports/athlete-train
     { provide: TRAINING_SESSION_REPO,  useClass: MikroTrainingSessionRepository },
     { provide: ATHLETE_TRAINING_SESSION_REPO, useClass: MikroAthleteTrainingSessionRepository },
 
-    // use-cases
-    TrainingSessionUseCase,
+    //presenters
     TrainingSessionPresenter,
     AthleteTrainingSessionPresenter,
   ],


### PR DESCRIPTION
- Replace @mikro-orm/postgresql imports with @mikro-orm/core for better compatibility
- Add @Injectable() decorators to repository classes for proper dependency injection
- Reorganize imports in training-session.module.ts for better readability
- Update MikroOrmModule.forFeature configuration to use explicit entities object
- Add missing AthleteTrainingSession entity to module imports
- Clean up module providers structure and remove duplicate use-case registration