### PR TITLE
♻️ refactor: move PhysicalMetric entity to athlete domain

### DIFF
--- a/apps/api/src/modules/athletes/athlete/domain/athlete.entity.ts
+++ b/apps/api/src/modules/athletes/athlete/domain/athlete.entity.ts
@@ -9,7 +9,7 @@ import {
 import { AthleteTrainingSession } from '../../../training/training-session/domain/athlete-training-session.entity'
 import { CompetitorStatus } from '../../competitor-status/competitor-status.entity';
 import { PersonalRecord } from '../../personal-record/personal-record.entity';
-import { PhysicalMetric } from '../../physical-metric/physical-metric.entity';
+import { PhysicalMetric } from './physical-metric.entity';
 import { User } from '../../../identity/auth/auth.entity';
 
 @Entity()

--- a/apps/api/src/modules/athletes/athlete/domain/physical-metric.entity.ts
+++ b/apps/api/src/modules/athletes/athlete/domain/physical-metric.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Athlete } from '../athlete/domain/athlete.entity';
+import { Athlete } from './athlete.entity';
 
 @Entity()
 export class PhysicalMetric {

--- a/apps/api/src/seeders/physical-metric.seeder.ts
+++ b/apps/api/src/seeders/physical-metric.seeder.ts
@@ -1,6 +1,6 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Athlete } from '../modules/athletes/athlete/domain/athlete.entity';
-import { PhysicalMetric } from '../modules/athletes/physical-metric/physical-metric.entity';
+import { PhysicalMetric } from '../modules/athletes/athlete/domain/physical-metric.entity';
 
 export async function seedPhysicalMetrics(em: EntityManager): Promise<void> {
   console.log('Seeding physical metrics...');


### PR DESCRIPTION
- Move physical-metric.entity.ts from athletes/physical-metric/ to athletes/athlete/domain/
- Update import paths in athlete.entity.ts and physical-metric.seeder.ts
- Consolidate physical metric functionality within athlete domain