### PR TITLE
🐛 fix: disable TypeScript metadata provider in production

### DIFF
--- a/apps/api/src/config/mikro-orm.config.ts
+++ b/apps/api/src/config/mikro-orm.config.ts
@@ -11,16 +11,17 @@ type CreateMikroOrmOptions = {
 export function createMikroOrmOptions(options?: CreateMikroOrmOptions) {
   const { isTest, ...restOptions } = options ?? {};
   const isTestEnvironment = isTest || config.env === 'test';
+  const isProduction = config.env === 'production';
 
   const _options: Options = defineConfig({
     entities: ['./dist/**/*.entity.js'],
-    entitiesTs: ['./src/**/*.entity.ts'],
+    entitiesTs: isProduction ? undefined : ['./src/**/*.entity.ts'],
     dbName: config.database.name,
     host: config.database.host,
     port: config.database.port,
     user: config.database.user,
     password: config.database.password,
-    metadataProvider: TsMorphMetadataProvider,
+    metadataProvider: isProduction ? undefined : TsMorphMetadataProvider,
     forceUtcTimezone: true,
     extensions: [SeedManager, Migrator],
     seeder: {


### PR DESCRIPTION
Conditionally disable entitiesTs and TsMorphMetadataProvider when NODE_ENV=production to prevent MikroORM from looking for TypeScript source files that don't exist in the Docker production build.