### PR TITLE
🐛 fix: use compiled JS config for production database seeding

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -52,4 +52,4 @@ ENV MIKRO_ORM_CLI_USE_TS_NODE=false
 ENV MIKRO_ORM_CLI_CONFIG=dist/config/mikro-orm.config.js
 
 # Start the application after syncing the database and optionally seeding
-CMD ["sh", "-c", "pnpm db:sync && if [ \"$SEED_DB\" = \"true\" ]; then pnpm db:seed; fi && pnpm run start:prod"]
+CMD ["sh", "-c", "pnpm db:sync && if [ \"$SEED_DB\" = \"true\" ]; then pnpm db:seed:prod; fi && pnpm run start:prod"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "db:migration:create": "npx mikro-orm migration:create",
     "db:migration:list": "npx mikro-orm migration:list",
     "db:seed": "npx mikro-orm seeder:run --config=./src/config/mikro-orm.config.ts",
+    "db:seed:prod": "npx mikro-orm seeder:run --config=./dist/config/mikro-orm.config.js",
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=src/test/",
     "test:unit:watch": "jest --testPathIgnorePatterns=src/test/ --watch",


### PR DESCRIPTION
  - Add db:seed:prod command using dist/config/mikro-orm.config.js
  - Update Dockerfile to use db:seed:prod for production seeding
  - Resolves API crash when SEED_DB=true in production environment