### PR TITLE
🐛 fix: prevent duplicate seeding by checking

### DIFF
--- a/apps/api/src/seeders/athlete.seeder.ts
+++ b/apps/api/src/seeders/athlete.seeder.ts
@@ -12,8 +12,8 @@ export async function seedAthletes(
   
   // Créer un super admin
   const superAdmin = new User();
-  superAdmin.name = 'Sten Levasseur';
-  superAdmin.email = 'levasseur.sten@gmail.com';
+  superAdmin.name = 'Super Admin';
+  superAdmin.email = 'super.admin@gmail.com';
   superAdmin.emailVerified = true;
   //Le champs isSuperAdmin est créé automatiquement par la config de better-auth
   await em.persistAndFlush(superAdmin);

--- a/apps/api/src/seeders/index.ts
+++ b/apps/api/src/seeders/index.ts
@@ -6,10 +6,18 @@ import { seedOrganizations } from './organization.seeder';
 import { seedPersonalRecords } from './personal-record.seeder';
 import { seedPhysicalMetrics } from './physical-metric.seeder';
 import { seedWorkouts } from './workout.seeder';
+import { User } from '../modules/identity/domain/auth/user.entity';
 
 export class MainSeeder extends Seeder {
   async run(em: EntityManager): Promise<void> {
     console.log('Running all seeders...');
+
+    // Vérifier si la base est déjà peuplée
+    const existingUser = await em.findOne(User, {});
+    if (existingUser) {
+      console.log('Database already contains users, skipping all seeding');
+      return;
+    }
 
     // 1. Seed des entités de base (exercices, complexes, workouts)
     await seedWorkouts(em);


### PR DESCRIPTION
  existing users

  - Add user existence check in MainSeeder before running all seeders
  - Skip entire seeding process if database already contains users
  - Resolves production crashes when SEED_DB=true on populated database