### PR TITLE
✨   feat(auth): add athleteid to session

### DIFF
--- a/apps/api/src/config/better-auth.config.ts
+++ b/apps/api/src/config/better-auth.config.ts
@@ -58,6 +58,15 @@ export function createAuthConfig(
         },
       },
     },
+    session: {
+      additionalFields: {
+        athleteId: {
+          type: "string",
+          required: false, // null for super admins users
+          input: false, // don't allow user to set athleteId
+        },
+      },
+    },
     emailAndPassword: {
       enabled: true,
       sendResetPassword: async (data, request) => {
@@ -176,24 +185,27 @@ export function createAuthConfig(
         create: {
           before: async (session) => {
             if (!em) return { data: session };
-            
+
             try {
               const emFork = em.fork();
               const memberRecord = await emFork.findOne(Member, { user: { id: session.userId } });
-              
-              console.log('🔧 [BetterAuth Hook] Setting activeOrganizationId:', {
+              const athlete = await emFork.findOne(Athlete, { user: { id: session.userId } });
+
+              console.log('🔧 [BetterAuth Hook] Setting session data:', {
                 userId: session.userId,
-                organizationId: memberRecord?.organization.id || null
+                organizationId: memberRecord?.organization.id || null,
+                athleteId: athlete?.id || null
               });
-              
+
               return {
                 data: {
                   ...session,
                   activeOrganizationId: memberRecord?.organization.id ?? null,
+                  athleteId: athlete?.id ?? null,
                 },
               };
             } catch (error) {
-              console.error('❌ [BetterAuth Hook] Error setting activeOrganizationId:', error);
+              console.error('❌ [BetterAuth Hook] Error setting session data:', error);
               return { data: session };
             }
           },

--- a/apps/api/src/modules/identity/domain/auth/session.entity.ts
+++ b/apps/api/src/modules/identity/domain/auth/session.entity.ts
@@ -37,6 +37,9 @@ export class Session {
   @Property({ fieldName: 'activeOrganizationId', nullable: true })
   activeOrganizationId?: string
 
+  @Property({ fieldName: 'athleteId', nullable: true })
+  athleteId?: string
+
   @ManyToOne(() => User, { fieldName: 'userId' })
   user!: User
 }

--- a/apps/mobile/src/components/TrainingScreen.tsx
+++ b/apps/mobile/src/components/TrainingScreen.tsx
@@ -5,7 +5,6 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
-  Alert,
 } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import TrainingDetailScreen from './TrainingDetailScreen';


### PR DESCRIPTION
  - Add athleteId to session via better-auth additionalFields
  - Populate athleteId in session.create.before hook from Athlete entity
  - Enable direct athlete identification from session (null for super admins)