### PR TITLE
refactor: align schema input type names across api and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ docker compose up -d
 
 4. **Set up the database:**
 
-Wait a few seconds for PostgreSQL to fully start, then run migrations or create a fresh database:
+Wait a few seconds for PostgreSQL to fully start, then create and seed the database:
 
 ```bash
-# Option 1: Run migrations
-pnpm --filter api db:migration:up
+# Create database and run migrations
+pnpm --filter api db:create
 
-# Option 2: Fresh database with seed data
-pnpm --filter api db:fresh
+# Seed demo data
+pnpm --filter api db:seed
 ```
 
 ### 5. Start development

--- a/apps/api/src/modules/athletes/application/ports/athlete-use-cases.port.ts
+++ b/apps/api/src/modules/athletes/application/ports/athlete-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateAthlete, UpdateAthlete } from '@dropit/schemas';
+import { CreateAthleteInput, UpdateAthleteInput } from '@dropit/schemas';
 import { Athlete } from '../../domain/athlete.entity';
 import { AthleteDetails } from './athlete.repository.port';
 
@@ -38,12 +38,12 @@ export interface IAthleteUseCases {
   /**
    * Create a new athlete
    */
-  create(data: CreateAthlete, userId: string): Promise<Athlete>;
+  create(data: CreateAthleteInput, userId: string): Promise<Athlete>;
 
   /**
    * Update an existing athlete
    */
-  update(idAthlete: string, data: UpdateAthlete, userId: string): Promise<Athlete>;
+  update(idAthlete: string, data: UpdateAthleteInput, userId: string): Promise<Athlete>;
 
   /**
    * Delete an athlete

--- a/apps/api/src/modules/athletes/application/ports/competitor-status-use-cases.port.ts
+++ b/apps/api/src/modules/athletes/application/ports/competitor-status-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateCompetitorStatus, UpdateCompetitorStatus } from '@dropit/schemas';
+import { CreateCompetitorStatusInput, UpdateCompetitorStatusInput } from '@dropit/schemas';
 import { CompetitorStatus } from '../../domain/competitor-status.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface ICompetitorStatusUseCases {
   /**
    * Create a new competitor status
    */
-  create(data: CreateCompetitorStatus, currentUserId: string, organizationId: string): Promise<CompetitorStatus>;
+  create(data: CreateCompetitorStatusInput, currentUserId: string, organizationId: string): Promise<CompetitorStatus>;
 
   /**
    * Update an existing competitor status
    */
-  update(id: string, data: UpdateCompetitorStatus, currentUserId: string, organizationId: string): Promise<CompetitorStatus>;
+  update(id: string, data: UpdateCompetitorStatusInput, currentUserId: string, organizationId: string): Promise<CompetitorStatus>;
 }
 
 /**

--- a/apps/api/src/modules/athletes/application/ports/personal-record-use-cases.port.ts
+++ b/apps/api/src/modules/athletes/application/ports/personal-record-use-cases.port.ts
@@ -1,7 +1,7 @@
 import {
-  CreatePersonalRecord,
+  CreatePersonalRecordInput,
   PersonalRecordsSummary,
-  UpdatePersonalRecord,
+  UpdatePersonalRecordInput,
 } from '@dropit/schemas';
 import { PersonalRecord } from '../../domain/personal-record.entity';
 
@@ -62,7 +62,7 @@ export interface IPersonalRecordUseCases {
    * @param organizationId - ID of the organization
    * @returns Created personal record entity
    */
-  create(data: CreatePersonalRecord, currentUserId: string, organizationId: string): Promise<PersonalRecord>;
+  create(data: CreatePersonalRecordInput, currentUserId: string, organizationId: string): Promise<PersonalRecord>;
 
   /**
    * Updates an existing personal record
@@ -72,7 +72,7 @@ export interface IPersonalRecordUseCases {
    * @param organizationId - ID of the organization
    * @returns Updated personal record entity
    */
-  update(id: string, data: UpdatePersonalRecord, currentUserId: string, organizationId: string): Promise<PersonalRecord>;
+  update(id: string, data: UpdatePersonalRecordInput, currentUserId: string, organizationId: string): Promise<PersonalRecord>;
 
   /**
    * Deletes a personal record

--- a/apps/api/src/modules/athletes/application/use-cases/athlete-use-cases.ts
+++ b/apps/api/src/modules/athletes/application/use-cases/athlete-use-cases.ts
@@ -1,5 +1,5 @@
 import { Athlete } from "../../domain/athlete.entity";
-import { CreateAthlete, UpdateAthlete } from "@dropit/schemas";
+import { CreateAthleteInput, UpdateAthleteInput } from "@dropit/schemas";
 import { IAthleteUseCases } from "../ports/athlete-use-cases.port";
 import { IAthleteRepository, AthleteDetails } from "../ports/athlete.repository.port";
 import { IUserUseCases } from "../../../auth/application/ports/user-use-cases.port";
@@ -119,7 +119,7 @@ export class AthleteUseCases implements IAthleteUseCases {
     return athletes;
   }
 
-  async create(data: CreateAthlete, userId: string): Promise<Athlete> {
+  async create(data: CreateAthleteInput, userId: string): Promise<Athlete> {
     //1. Get User from repository
     const user = await this.userUseCases.getOne(userId);
 
@@ -151,7 +151,7 @@ export class AthleteUseCases implements IAthleteUseCases {
     return athlete;
   }
 
-  async update(idAthlete: string, data: UpdateAthlete, userId: string): Promise<Athlete> {
+  async update(idAthlete: string, data: UpdateAthleteInput, userId: string): Promise<Athlete> {
     //1. Get Athlete
     const athlete = await this.athleteRepository.getOne(idAthlete);
 

--- a/apps/api/src/modules/athletes/application/use-cases/competitor-status.use-cases.ts
+++ b/apps/api/src/modules/athletes/application/use-cases/competitor-status.use-cases.ts
@@ -1,6 +1,6 @@
 import {
-  CreateCompetitorStatus,
-  UpdateCompetitorStatus,
+  CreateCompetitorStatusInput,
+  UpdateCompetitorStatusInput,
 } from '@dropit/schemas';
 import { CompetitorStatus } from '../../domain/competitor-status.entity';
 import { ICompetitorStatusUseCases } from '../ports/competitor-status-use-cases.port';
@@ -78,7 +78,7 @@ export class CompetitorStatusUseCases implements ICompetitorStatusUseCases {
   }
 
   async create(
-    data: CreateCompetitorStatus,
+    data: CreateCompetitorStatusInput,
     currentUserId: string,
     organizationId: string
   ): Promise<CompetitorStatus> {
@@ -129,7 +129,7 @@ export class CompetitorStatusUseCases implements ICompetitorStatusUseCases {
 
   async update(
     id: string,
-    data: UpdateCompetitorStatus,
+    data: UpdateCompetitorStatusInput,
     currentUserId: string,
     organizationId: string
   ): Promise<CompetitorStatus> {

--- a/apps/api/src/modules/athletes/application/use-cases/personal-record.use-cases.ts
+++ b/apps/api/src/modules/athletes/application/use-cases/personal-record.use-cases.ts
@@ -1,7 +1,7 @@
 import {
-  CreatePersonalRecord,
+  CreatePersonalRecordInput,
   PersonalRecordsSummary,
-  UpdatePersonalRecord,
+  UpdatePersonalRecordInput,
 } from '@dropit/schemas';
 import { PersonalRecord } from '../../domain/personal-record.entity';
 import { IPersonalRecordRepository } from '../ports/personal-record.repository.port';
@@ -180,7 +180,7 @@ export class PersonalRecordUseCases implements IPersonalRecordUseCases {
   }
 
   async create(
-    data: CreatePersonalRecord,
+    data: CreatePersonalRecordInput,
     currentUserId: string,
     organizationId: string
   ): Promise<PersonalRecord> {
@@ -235,7 +235,7 @@ export class PersonalRecordUseCases implements IPersonalRecordUseCases {
 
   async update(
     id: string,
-    data: UpdatePersonalRecord,
+    data: UpdatePersonalRecordInput,
     currentUserId: string,
     organizationId: string
   ): Promise<PersonalRecord> {

--- a/apps/api/src/modules/auth/application/onboarding.use-cases.ts
+++ b/apps/api/src/modules/auth/application/onboarding.use-cases.ts
@@ -1,4 +1,4 @@
-import { RequestAccess } from "@dropit/schemas";
+import { RequestAccessInput } from "@dropit/schemas";
 import { IOnboardingUseCases } from "./ports/onboarding-use-cases.port";
 import { INotificationUseCases } from "../../notification/application/ports/inbound/notification-use-cases.port";
 import { IInvitationRepository } from "./ports/invitation.repository.port";
@@ -15,9 +15,9 @@ export class OnboardingUseCases implements IOnboardingUseCases {
     private readonly memberRepository: IMemberRepository,
     private readonly userUseCases: IUserUseCases,
     private readonly athleteUseCases: IAthleteUseCases,
-  ) { }
+  ) {}
 
-  async createCoachAccessRequest(data: RequestAccess): Promise<void> {
+  async createCoachAccessRequest(data: RequestAccessInput): Promise<void> {
     await this.notificationUseCases.sendRequestAccess(data);
   }
 
@@ -28,14 +28,24 @@ export class OnboardingUseCases implements IOnboardingUseCases {
     const existingUser = await this.userUseCases.getByEmail(email);
 
     if (!existingUser) {
-      const user = await this.userUseCases.create({ name: email, email, emailVerified: false });
-      await this.athleteUseCases.create({ firstName: '', lastName: '' }, user.id);
+      const user = await this.userUseCases.create({
+        name: email,
+        email,
+        emailVerified: false,
+      });
+      await this.athleteUseCases.create(
+        { firstName: "", lastName: "" },
+        user.id,
+      );
       return { isNewUser: true, hasOtherOrganization: false };
     }
 
-    const existingMember = await this.memberRepository.findByUserId(existingUser.id);
+    const existingMember = await this.memberRepository.findByUserId(
+      existingUser.id,
+    );
     const hasOtherOrganization =
-      existingMember !== null && existingMember.organization.id !== organizationId;
+      existingMember !== null &&
+      existingMember.organization.id !== organizationId;
 
     return { isNewUser: false, hasOtherOrganization };
   }
@@ -47,7 +57,7 @@ export class OnboardingUseCases implements IOnboardingUseCases {
       throw InvitationException.notFound(invitationId);
     }
 
-    if (invitation.status !== 'pending' || invitation.expiresAt < new Date()) {
+    if (invitation.status !== "pending" || invitation.expiresAt < new Date()) {
       throw InvitationException.expiredOrUsed();
     }
 
@@ -70,7 +80,7 @@ export class OnboardingUseCases implements IOnboardingUseCases {
     member.createdAt = new Date();
     await this.memberRepository.save(member);
 
-    invitation.status = 'accepted';
+    invitation.status = "accepted";
     await this.invitationRepository.save(invitation);
   }
 }

--- a/apps/api/src/modules/auth/application/ports/onboarding-use-cases.port.ts
+++ b/apps/api/src/modules/auth/application/ports/onboarding-use-cases.port.ts
@@ -1,7 +1,7 @@
-import { RequestAccess } from "@dropit/schemas";
+import { RequestAccessInput } from "@dropit/schemas";
 
 export interface IOnboardingUseCases {
-  createCoachAccessRequest(data: RequestAccess): Promise<void>;
+  createCoachAccessRequest(data: RequestAccessInput): Promise<void>;
   acceptInvitation(invitationId: string): Promise<void>;
   prepareUserForInvitation(email: string, organizationId: string): Promise<{ isNewUser: boolean; hasOtherOrganization: boolean }>;
 }

--- a/apps/api/src/modules/notification/application/ports/inbound/notification-use-cases.port.ts
+++ b/apps/api/src/modules/notification/application/ports/inbound/notification-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { RequestAccess } from "@dropit/schemas";
+import { RequestAccessInput } from "@dropit/schemas";
 
 export type OrganizationInvitationParams = {
   organizationId: string;
@@ -8,11 +8,15 @@ export type OrganizationInvitationParams = {
   invitationToken: string;
   isNewUser: boolean;
   hasOtherOrganization: boolean;
-}
+};
 
 export type OtpParams =
-  | { otp: string, email: string, type: 'sign-in' | 'email-verification' | 'forget-password' }
-  | { otp: string, phoneNumber: string };
+  | {
+      otp: string;
+      email: string;
+      type: "sign-in" | "email-verification" | "forget-password";
+    }
+  | { otp: string; phoneNumber: string };
 
 /**
  * Notification Use Cases Port (Port IN)
@@ -28,7 +32,6 @@ export type OtpParams =
  * via dependency injection.
  */
 export interface INotificationUseCases {
-
   /**
    * Send an invitation email to join an organization
    *
@@ -38,24 +41,25 @@ export interface INotificationUseCases {
    * - If user exists: sends email + push notification
    * - If user doesn't exist: sends email only with signup link
    */
-  sendOrganizationInvitation(params: OrganizationInvitationParams): Promise<void>;
+  sendOrganizationInvitation(
+    params: OrganizationInvitationParams,
+  ): Promise<void>;
 
-  /** 
+  /**
    * Send a one-time password (OTP) code
    *
    * @description
    */
-  sendOtp(params: OtpParams): Promise<void>
+  sendOtp(params: OtpParams): Promise<void>;
 
   /**
    * Send a notification to super admin to new request access from backoffice form
    */
-  sendRequestAccess(params: RequestAccess): Promise<void>;
+  sendRequestAccess(params: RequestAccessInput): Promise<void>;
 }
-
 
 /**
  * Injection token for INotificationUseCases
  * Use this token in @Inject() decorators
  */
-export const NOTIFICATION_USE_CASES = Symbol('NOTIFICATION_USE_CASES');
+export const NOTIFICATION_USE_CASES = Symbol("NOTIFICATION_USE_CASES");

--- a/apps/api/src/modules/notification/application/use-cases/notification.use-cases.ts
+++ b/apps/api/src/modules/notification/application/use-cases/notification.use-cases.ts
@@ -1,11 +1,15 @@
-import { INotificationUseCases, OtpParams, OrganizationInvitationParams } from '../ports/inbound/notification-use-cases.port';
+import {
+  INotificationUseCases,
+  OtpParams,
+  OrganizationInvitationParams,
+} from "../ports/inbound/notification-use-cases.port";
 import {
   INotificationPort,
   KIND,
   type NotificationRequest,
   RECIPIENT_TYPE,
-} from '../ports/outbound/notification.port';
-import { RequestAccess } from '@dropit/schemas';
+} from "../ports/outbound/notification.port";
+import { RequestAccessInput } from "@dropit/schemas";
 
 /**
  * Notification Use Cases Implementation
@@ -15,15 +19,17 @@ import { RequestAccess } from '@dropit/schemas';
  * Dependencies are plain interfaces (ports) — wired by the module via useFactory.
  */
 export class NotificationUseCase implements INotificationUseCases {
-  constructor(
-    private readonly notificationPort: INotificationPort,
-  ) { }
+  constructor(private readonly notificationPort: INotificationPort) {}
 
-  async sendOrganizationInvitation(params: OrganizationInvitationParams): Promise<void> {
+  async sendOrganizationInvitation(
+    params: OrganizationInvitationParams,
+  ): Promise<void> {
     try {
       const notificationRequest: NotificationRequest = {
         kind: KIND.ORGANIZATION_INVITATION,
-        recipientType: params.isNewUser ? RECIPIENT_TYPE.NEW_USER : RECIPIENT_TYPE.EXISTING_USER,
+        recipientType: params.isNewUser
+          ? RECIPIENT_TYPE.NEW_USER
+          : RECIPIENT_TYPE.EXISTING_USER,
         hasOtherOrganization: params.hasOtherOrganization,
         organizationId: params.organizationId,
         organizationName: params.organizationName,
@@ -41,7 +47,7 @@ export class NotificationUseCase implements INotificationUseCases {
     const notificationRequest: NotificationRequest = {
       kind: KIND.OTP,
       otpParams: params,
-    }
+    };
     try {
       await this.notificationPort.send(notificationRequest);
     } catch (error) {
@@ -49,17 +55,17 @@ export class NotificationUseCase implements INotificationUseCases {
     }
   }
 
-  async sendRequestAccess(params: RequestAccess): Promise<void> {
+  async sendRequestAccess(params: RequestAccessInput): Promise<void> {
     const notificationRequest: NotificationRequest = {
       kind: KIND.REQUEST_ACCESS,
       email: params.email,
       name: params.name,
-    }
+    };
 
     try {
       await this.notificationPort.send(notificationRequest);
     } catch (error) {
-      console.error('Failed to send notification request access', error);
+      console.error("Failed to send notification request access", error);
     }
   }
 }

--- a/apps/api/src/modules/notification/infrastructure/channels/email/email.adapter.ts
+++ b/apps/api/src/modules/notification/infrastructure/channels/email/email.adapter.ts
@@ -1,7 +1,15 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { config } from "src/config/env.config";
-import { KIND, NotificationRequest } from "../../../application/ports/outbound/notification.port";
-import { EMAIL_TRANSPORT, EmailData, IEmailChannel, IEmailTransport } from "./email-channel.port";
+import {
+  KIND,
+  NotificationRequest,
+} from "../../../application/ports/outbound/notification.port";
+import {
+  EMAIL_TRANSPORT,
+  EmailData,
+  IEmailChannel,
+  IEmailTransport,
+} from "./email-channel.port";
 import { renderEmailLayout } from "./email-template";
 
 @Injectable()
@@ -9,7 +17,7 @@ export class EmailAdapter implements IEmailChannel {
   constructor(
     @Inject(EMAIL_TRANSPORT)
     private readonly transport: IEmailTransport,
-  ) { }
+  ) {}
 
   async send(request: NotificationRequest): Promise<void> {
     const emailData = this.buildEmail(request);
@@ -22,16 +30,18 @@ export class EmailAdapter implements IEmailChannel {
         return {
           to: request.email,
           subject: `Invitation à rejoindre ${request.organizationName}`,
-          htmlContent: this.renderOrganizationInvitation(request)
-        }
+          htmlContent: this.renderOrganizationInvitation(request),
+        };
 
       case KIND.OTP: {
-        if (!('email' in request.otpParams)) {
-          throw new Error('Otp notification routed to email channel without email address');
+        if (!("email" in request.otpParams)) {
+          throw new Error(
+            "Otp notification routed to email channel without email address",
+          );
         }
         return {
           to: request.otpParams.email,
-          subject: 'Votre code de vérification DropIt',
+          subject: "Votre code de vérification DropIt",
           htmlContent: this.renderOtpCode(request),
         };
       }
@@ -39,9 +49,9 @@ export class EmailAdapter implements IEmailChannel {
       case KIND.REQUEST_ACCESS:
         return {
           to: config.email.sender.fromEmail,
-          subject: 'Demande de nouvel accès coach',
+          subject: "Demande de nouvel accès coach",
           htmlContent: this.renderRequestAccess(request),
-        }
+        };
 
       default: {
         const _exhaustive: never = request;
@@ -50,14 +60,19 @@ export class EmailAdapter implements IEmailChannel {
     }
   }
 
-  private renderOrganizationInvitation(request: Extract<NotificationRequest, { kind: typeof KIND.ORGANIZATION_INVITATION }>): string {
+  private renderOrganizationInvitation(
+    request: Extract<
+      NotificationRequest,
+      { kind: typeof KIND.ORGANIZATION_INVITATION }
+    >,
+  ): string {
     const inviteLink = `${config.appUrl}/accept-invitation/${request.invitationToken}`;
 
     const warningBlock = request.hasOtherOrganization
       ? `<p style="margin-top: 20px; padding: 12px 16px; background: #fef3c7; border-left: 4px solid #f59e0b; border-radius: 4px; color: #92400e; font-size: 14px;">
           ⚠️ <strong>Attention :</strong> En acceptant cette invitation, vous quitterez votre club actuel.
         </p>`
-      : '';
+      : "";
 
     return renderEmailLayout({
       title: `Invitation à rejoindre ${request.organizationName}`,
@@ -88,12 +103,14 @@ export class EmailAdapter implements IEmailChannel {
     });
   }
 
-  private renderRequestAccess(request: Extract<NotificationRequest, { kind: typeof KIND.REQUEST_ACCESS }>): string {
+  private renderRequestAccess(
+    request: Extract<NotificationRequest, { kind: typeof KIND.REQUEST_ACCESS }>,
+  ): string {
     const name = this.escapeHtml(request.name);
     const email = this.escapeHtml(request.email);
 
     return renderEmailLayout({
-      title: 'Nouvelle demande d\'accès coach',
+      title: "Nouvelle demande d'accès coach",
       headerContent: `
         <h1>DropIt</h1>
         <h2>Nouvelle demande d'accès coach</h2>
@@ -112,22 +129,25 @@ export class EmailAdapter implements IEmailChannel {
           </tr>
         </table>
       `,
-      footerContent: '<p>Cet email a été généré automatiquement par DropIt.</p>',
+      footerContent:
+        "<p>Cet email a été généré automatiquement par DropIt.</p>",
     });
   }
 
   private escapeHtml(value: string): string {
     return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#x27;');
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#x27;");
   }
 
-  private renderOtpCode(request: Extract<NotificationRequest, { kind: typeof KIND.OTP }>): string {
+  private renderOtpCode(
+    request: Extract<NotificationRequest, { kind: typeof KIND.OTP }>,
+  ): string {
     return renderEmailLayout({
-      title: 'Votre code de vérification',
+      title: "Votre code de vérification",
       headerContent: "<h1>Code de vérification</h1>",
       extraStyles:
         ".otp-code { font-size: 32px; font-weight: bold; text-align: center; background: white; padding: 20px; border-radius: 8px; letter-spacing: 8px; }",
@@ -144,4 +164,3 @@ export class EmailAdapter implements IEmailChannel {
     });
   }
 }
-

--- a/apps/api/src/modules/training/application/ports/complex-category-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/complex-category-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateComplexCategory, UpdateComplexCategory } from '@dropit/schemas';
+import { CreateComplexCategoryInput, UpdateComplexCategoryInput } from '@dropit/schemas';
 import { ComplexCategory } from '../../domain/complex-category.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface IComplexCategoryUseCases {
   /**
    * Create a new complex category
    */
-  create(data: CreateComplexCategory, organizationId: string, userId: string): Promise<ComplexCategory>;
+  create(data: CreateComplexCategoryInput, organizationId: string, userId: string): Promise<ComplexCategory>;
 
   /**
    * Update a complex category
    */
-  update(complexCategoryId: string, data: UpdateComplexCategory, organizationId: string, userId: string): Promise<ComplexCategory>;
+  update(complexCategoryId: string, data: UpdateComplexCategoryInput, organizationId: string, userId: string): Promise<ComplexCategory>;
 
   /**
    * Delete a complex category

--- a/apps/api/src/modules/training/application/ports/complex-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/complex-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateComplex, UpdateComplex } from '@dropit/schemas';
+import { CreateComplexInput, UpdateComplexInput } from '@dropit/schemas';
 import { Complex } from '../../domain/complex.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface IComplexUseCases {
   /**
    * Create a new complex
    */
-  create(data: CreateComplex, userId: string, organizationId: string): Promise<Complex>;
+  create(data: CreateComplexInput, userId: string, organizationId: string): Promise<Complex>;
 
   /**
    * Update a complex
    */
-  update(complexId: string, data: UpdateComplex, userId: string, organizationId: string): Promise<Complex>;
+  update(complexId: string, data: UpdateComplexInput, userId: string, organizationId: string): Promise<Complex>;
 
   /**
    * Delete a complex

--- a/apps/api/src/modules/training/application/ports/exercise-category-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/exercise-category-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateExerciseCategory, UpdateExerciseCategory } from '@dropit/schemas';
+import { CreateExerciseCategoryInput, UpdateExerciseCategoryInput } from '@dropit/schemas';
 import { ExerciseCategory } from '../../domain/exercise-category.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface IExerciseCategoryUseCases {
   /**
    * Create a new exercise category
    */
-  create(data: CreateExerciseCategory, organizationId: string, userId: string): Promise<ExerciseCategory>;
+  create(data: CreateExerciseCategoryInput, organizationId: string, userId: string): Promise<ExerciseCategory>;
 
   /**
    * Update an exercise category
    */
-  update(exerciseCategoryId: string, data: UpdateExerciseCategory, organizationId: string, userId: string): Promise<ExerciseCategory>;
+  update(exerciseCategoryId: string, data: UpdateExerciseCategoryInput, organizationId: string, userId: string): Promise<ExerciseCategory>;
 
   /**
    * Delete an exercise category

--- a/apps/api/src/modules/training/application/ports/exercise-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/exercise-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateExercise, UpdateExercise } from '@dropit/schemas';
+import { CreateExerciseInput, UpdateExerciseInput } from '@dropit/schemas';
 import { Exercise } from '../../domain/exercise.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface IExerciseUseCases {
   /**
    * Create a new exercise
    */
-  create(data: CreateExercise, userId: string, organizationId: string): Promise<Exercise>;
+  create(data: CreateExerciseInput, userId: string, organizationId: string): Promise<Exercise>;
 
   /**
    * Update an exercise
    */
-  update(exerciseId: string, data: UpdateExercise, userId: string, organizationId: string): Promise<Exercise>;
+  update(exerciseId: string, data: UpdateExerciseInput, userId: string, organizationId: string): Promise<Exercise>;
 
   /**
    * Search exercises by name

--- a/apps/api/src/modules/training/application/ports/training-session-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/training-session-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateTrainingSession, UpdateAthleteTrainingSession, UpdateTrainingSession } from '@dropit/schemas';
+import { CreateTrainingSessionInput, UpdateAthleteTrainingSessionInput, UpdateTrainingSessionInput } from '@dropit/schemas';
 import { TrainingSession } from '../../domain/training-session.entity';
 import { AthleteTrainingSession } from '../../domain/athlete-training-session.entity';
 
@@ -33,12 +33,12 @@ export interface ITrainingSessionUseCases {
   /**
    * Create a new training session
    */
-  create(data: CreateTrainingSession, organizationId: string, userId: string): Promise<TrainingSession>;
+  create(data: CreateTrainingSessionInput, organizationId: string, userId: string): Promise<TrainingSession>;
 
   /**
    * Update a training session
    */
-  update(sessionId: string, data: UpdateTrainingSession, organizationId: string, userId: string): Promise<TrainingSession>;
+  update(sessionId: string, data: UpdateTrainingSessionInput, organizationId: string, userId: string): Promise<TrainingSession>;
 
   /**
    * Delete a training session
@@ -61,7 +61,7 @@ export interface ITrainingSessionUseCases {
   updateAthleteTrainingSession(
     athleteId: string,
     athleteTrainingSessionId: string,
-    data: UpdateAthleteTrainingSession,
+    data: UpdateAthleteTrainingSessionInput,
     userId: string
   ): Promise<AthleteTrainingSession>;
 }

--- a/apps/api/src/modules/training/application/ports/workout-category-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/workout-category-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateWorkoutCategory, UpdateWorkoutCategory } from '@dropit/schemas';
+import { CreateWorkoutCategoryInput, UpdateWorkoutCategoryInput } from '@dropit/schemas';
 import { WorkoutCategory } from '../../domain/workout-category.entity';
 
 /**
@@ -27,12 +27,12 @@ export interface IWorkoutCategoryUseCases {
   /**
    * Create a new workout category
    */
-  create(data: CreateWorkoutCategory, organizationId: string, userId: string): Promise<WorkoutCategory>;
+  create(data: CreateWorkoutCategoryInput, organizationId: string, userId: string): Promise<WorkoutCategory>;
 
   /**
    * Update a workout category
    */
-  update(workoutCategoryId: string, data: UpdateWorkoutCategory, organizationId: string, userId: string): Promise<WorkoutCategory>;
+  update(workoutCategoryId: string, data: UpdateWorkoutCategoryInput, organizationId: string, userId: string): Promise<WorkoutCategory>;
 
   /**
    * Delete a workout category

--- a/apps/api/src/modules/training/application/ports/workout-use-cases.port.ts
+++ b/apps/api/src/modules/training/application/ports/workout-use-cases.port.ts
@@ -1,4 +1,4 @@
-import { CreateWorkout, UpdateWorkout } from '@dropit/schemas';
+import { CreateWorkoutInput, UpdateWorkoutInput } from '@dropit/schemas';
 import { Workout } from '../../domain/workout.entity';
 
 /**
@@ -32,12 +32,12 @@ export interface IWorkoutUseCases {
   /**
    * Create a new workout
    */
-  createWorkout(workout: CreateWorkout, organizationId: string, userId: string): Promise<Workout>;
+  createWorkout(workout: CreateWorkoutInput, organizationId: string, userId: string): Promise<Workout>;
 
   /**
    * Update a workout
    */
-  updateWorkout(id: string, workout: UpdateWorkout, organizationId: string, userId: string): Promise<Workout>;
+  updateWorkout(id: string, workout: UpdateWorkoutInput, organizationId: string, userId: string): Promise<Workout>;
 
   /**
    * Delete a workout

--- a/apps/api/src/modules/training/application/use-cases/complex-category.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/complex-category.use-cases.ts
@@ -1,7 +1,7 @@
 import { IComplexCategoryRepository } from '../ports/complex-category.repository.port';
 import { IMemberUseCases } from '../../../auth/application/ports/member-use-cases.port';
 import { IUserUseCases } from '../../../auth/application/ports/user-use-cases.port';
-import { CreateComplexCategory, UpdateComplexCategory } from '@dropit/schemas';
+import { CreateComplexCategoryInput, UpdateComplexCategoryInput } from '@dropit/schemas';
 import { ComplexCategory } from '../../domain/complex-category.entity';
 import { IComplexCategoryUseCases } from '../ports/complex-category-use-cases.port';
 import {
@@ -66,7 +66,7 @@ export class ComplexCategoryUseCase implements IComplexCategoryUseCases {
     return complexCategories;
   }
 
-  async create(data: CreateComplexCategory, organizationId: string, userId: string): Promise<ComplexCategory> {
+  async create(data: CreateComplexCategoryInput, organizationId: string, userId: string): Promise<ComplexCategory> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
     if (!isCoach) {
@@ -101,7 +101,7 @@ export class ComplexCategoryUseCase implements IComplexCategoryUseCases {
     return created;
   }
 
-  async update(complexCategoryId: string, data: UpdateComplexCategory, organizationId: string, userId: string): Promise<ComplexCategory> {
+  async update(complexCategoryId: string, data: UpdateComplexCategoryInput, organizationId: string, userId: string): Promise<ComplexCategory> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
     if (!isCoach) {

--- a/apps/api/src/modules/training/application/use-cases/complex.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/complex.use-cases.ts
@@ -4,7 +4,7 @@ import { IExerciseRepository } from '../ports/exercise.repository.port';
 import { IExerciseComplexRepository } from '../ports/exercise-complex.repository.port';
 import { IMemberUseCases } from '../../../auth/application/ports/member-use-cases.port';
 import { IUserUseCases } from '../../../auth/application/ports/user-use-cases.port';
-import { CreateComplex, UpdateComplex } from '@dropit/schemas';
+import { CreateComplexInput, UpdateComplexInput } from '@dropit/schemas';
 import { Complex } from '../../domain/complex.entity';
 import { ExerciseComplex } from '../../domain/exercise-complex.entity';
 import { IComplexUseCases } from '../ports/complex-use-cases.port';
@@ -80,7 +80,7 @@ export class ComplexUseCase implements IComplexUseCases {
     return complexes;
   }
 
-  async create(data: CreateComplex, organizationId: string, userId: string): Promise<Complex> {
+  async create(data: CreateComplexInput, organizationId: string, userId: string): Promise<Complex> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 
@@ -141,7 +141,7 @@ export class ComplexUseCase implements IComplexUseCases {
     return complexCreated;
   }
 
-  async update(complexId: string, data: UpdateComplex, organizationId: string, userId: string): Promise<Complex> {
+  async update(complexId: string, data: UpdateComplexInput, organizationId: string, userId: string): Promise<Complex> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
     if (!isCoach) {

--- a/apps/api/src/modules/training/application/use-cases/exercise-category.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/exercise-category.use-cases.ts
@@ -1,7 +1,7 @@
 import { IExerciseCategoryRepository } from '../ports/exercise-category.repository.port';
 import { IMemberUseCases } from '../../../auth/application/ports/member-use-cases.port';
 import { IUserUseCases } from '../../../auth/application/ports/user-use-cases.port';
-import { CreateExerciseCategory, UpdateExerciseCategory } from '@dropit/schemas';
+import { CreateExerciseCategoryInput, UpdateExerciseCategoryInput } from '@dropit/schemas';
 import { ExerciseCategory } from '../../domain/exercise-category.entity';
 import { IExerciseCategoryUseCases } from '../ports/exercise-category-use-cases.port';
 import {
@@ -67,7 +67,7 @@ export class ExerciseCategoryUseCase implements IExerciseCategoryUseCases {
     return exerciseCategories;
   }
 
-  async create(data: CreateExerciseCategory, organizationId: string, userId: string): Promise<ExerciseCategory> {
+  async create(data: CreateExerciseCategoryInput, organizationId: string, userId: string): Promise<ExerciseCategory> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 
@@ -103,7 +103,7 @@ export class ExerciseCategoryUseCase implements IExerciseCategoryUseCases {
     return createdExerciseCategory;
   }
 
-  async update(exerciseCategoryId: string, data: UpdateExerciseCategory, organizationId: string, userId: string): Promise<ExerciseCategory> {
+  async update(exerciseCategoryId: string, data: UpdateExerciseCategoryInput, organizationId: string, userId: string): Promise<ExerciseCategory> {
     // 1. Check if the user is coach of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 

--- a/apps/api/src/modules/training/application/use-cases/exercise.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/exercise.use-cases.ts
@@ -1,6 +1,6 @@
 import { IExerciseRepository } from '../ports/exercise.repository.port';
 import { IExerciseCategoryRepository } from '../ports/exercise-category.repository.port';
-import { CreateExercise, UpdateExercise } from '@dropit/schemas';
+import { CreateExerciseInput, UpdateExerciseInput } from '@dropit/schemas';
 import { Exercise } from '../../domain/exercise.entity';
 import { IMemberUseCases } from '../../../auth/application/ports/member-use-cases.port';
 import { IUserUseCases } from '../../../auth/application/ports/user-use-cases.port';
@@ -98,7 +98,7 @@ export class ExerciseUseCase implements IExerciseUseCases {
     return exercises;
   }
 
-  async create(data: CreateExercise, organizationId: string, userId: string): Promise<Exercise> {
+  async create(data: CreateExerciseInput, organizationId: string, userId: string): Promise<Exercise> {
     //1. Check if the user is admin of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 
@@ -152,7 +152,7 @@ export class ExerciseUseCase implements IExerciseUseCases {
     return createdExercise;
   }
 
-  async update(exerciseId: string, data: UpdateExercise, organizationId: string, userId: string): Promise<Exercise> {
+  async update(exerciseId: string, data: UpdateExerciseInput, organizationId: string, userId: string): Promise<Exercise> {
     //1. Check if the user is admin of this organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 

--- a/apps/api/src/modules/training/application/use-cases/training-session.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/training-session.use-cases.ts
@@ -1,6 +1,6 @@
 import { ITrainingSessionRepository } from '../ports/training-session.repository.port';
 import { IOrganizationUseCases } from '../../../auth/application/ports/organization-use-cases.port';
-import { CreateTrainingSession, UpdateAthleteTrainingSession, UpdateTrainingSession } from '@dropit/schemas';
+import { CreateTrainingSessionInput, UpdateAthleteTrainingSessionInput, UpdateTrainingSessionInput } from '@dropit/schemas';
 import { TrainingSession } from '../../domain/training-session.entity';
 import { AthleteTrainingSession } from '../../domain/athlete-training-session.entity';
 import { IAthleteTrainingSessionRepository } from '../ports/athlete-training-session.repository.port';
@@ -157,7 +157,7 @@ export class TrainingSessionUseCase implements ITrainingSessionUseCases {
     return athleteTrainingSession;
   }
 
-  async create(data: CreateTrainingSession, organizationId: string, userId: string): Promise<TrainingSession> {
+  async create(data: CreateTrainingSessionInput, organizationId: string, userId: string): Promise<TrainingSession> {
     //1. Get organization from repository
     const organization = await this.organizationUseCases.getOne(organizationId);
 
@@ -222,7 +222,7 @@ export class TrainingSessionUseCase implements ITrainingSessionUseCases {
     return createdTrainingSession;
   }
 
-  async update(sessionId: string, data: UpdateTrainingSession, organizationId: string, userId: string): Promise<TrainingSession> {
+  async update(sessionId: string, data: UpdateTrainingSessionInput, organizationId: string, userId: string): Promise<TrainingSession> {
     //1. Check if the user is admin of this organization
     const isAdmin = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 
@@ -302,7 +302,7 @@ export class TrainingSessionUseCase implements ITrainingSessionUseCases {
     return updatedTrainingSession;
   }
 
-  async updateAthleteTrainingSession(athleteId: string, athleteTrainingSessionId: string, data: UpdateAthleteTrainingSession, userId: string): Promise<AthleteTrainingSession> {
+  async updateAthleteTrainingSession(athleteId: string, athleteTrainingSessionId: string, data: UpdateAthleteTrainingSessionInput, userId: string): Promise<AthleteTrainingSession> {
     //1. Get athlete from repository
     const athlete = await this.athleteRepository.getOne(athleteId);
 

--- a/apps/api/src/modules/training/application/use-cases/workout-category.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/workout-category.use-cases.ts
@@ -1,7 +1,7 @@
 import { IWorkoutCategoryRepository } from '../ports/workout-category.repository.port';
 import { IMemberUseCases } from '../../../auth/application/ports/member-use-cases.port';
 import { IUserUseCases } from '../../../auth/application/ports/user-use-cases.port';
-import { CreateWorkoutCategory, UpdateWorkoutCategory } from '@dropit/schemas';
+import { CreateWorkoutCategoryInput, UpdateWorkoutCategoryInput } from '@dropit/schemas';
 import { WorkoutCategory } from '../../domain/workout-category.entity';
 import { IWorkoutCategoryUseCases } from '../ports/workout-category-use-cases.port';
 import {
@@ -64,7 +64,7 @@ export class WorkoutCategoryUseCase implements IWorkoutCategoryUseCases {
     return workoutCategories;
   }
 
-  async create(data: CreateWorkoutCategory, organizationId: string, userId: string): Promise<WorkoutCategory> {
+  async create(data: CreateWorkoutCategoryInput, organizationId: string, userId: string): Promise<WorkoutCategory> {
     // 1. Verify user is a coach of the organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
     if (!isCoach) {
@@ -99,7 +99,7 @@ export class WorkoutCategoryUseCase implements IWorkoutCategoryUseCases {
     return created;
   }
 
-  async update(workoutCategoryId: string, data: UpdateWorkoutCategory, organizationId: string, userId: string): Promise<WorkoutCategory> {
+  async update(workoutCategoryId: string, data: UpdateWorkoutCategoryInput, organizationId: string, userId: string): Promise<WorkoutCategory> {
     // 1. Verify user is a coach of the organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
     if (!isCoach) {

--- a/apps/api/src/modules/training/application/use-cases/workout.use-cases.ts
+++ b/apps/api/src/modules/training/application/use-cases/workout.use-cases.ts
@@ -1,4 +1,4 @@
-import { CreateWorkout, UpdateWorkout } from '@dropit/schemas';
+import { CreateWorkoutInput, UpdateWorkoutInput } from '@dropit/schemas';
 import { Athlete } from '../../../athletes/domain/athlete.entity';
 import { AthleteTrainingSession } from '../../domain/athlete-training-session.entity';
 import { TrainingSession } from '../../domain/training-session.entity';
@@ -118,7 +118,7 @@ export class WorkoutUseCases implements IWorkoutUseCases {
     return workout;
   }
 
-  async createWorkout(workout: CreateWorkout, organizationId: string, userId: string): Promise<Workout> {
+  async createWorkout(workout: CreateWorkoutInput, organizationId: string, userId: string): Promise<Workout> {
     //1. Check if user is coach of the organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 
@@ -230,7 +230,7 @@ export class WorkoutUseCases implements IWorkoutUseCases {
     return workoutCreated;
   }
 
-  async updateWorkout(id: string, workout: UpdateWorkout, organizationId: string, userId: string): Promise<Workout> {
+  async updateWorkout(id: string, workout: UpdateWorkoutInput, organizationId: string, userId: string): Promise<Workout> {
     //1. Check if user is coach of the organization
     const isCoach = await this.memberUseCases.isUserCoachInOrganization(userId, organizationId);
 

--- a/apps/api/src/test/exercise.integration.ts
+++ b/apps/api/src/test/exercise.integration.ts
@@ -1,4 +1,4 @@
-import { CreateExercise, ExerciseCategoryDto, ExerciseDto } from '@dropit/schemas';
+import { CreateExerciseInput, ExerciseCategoryDto, ExerciseDto } from '@dropit/schemas';
 import { MikroORM } from '@mikro-orm/core';
 import { ExerciseCategoryUseCase } from '../modules/training/application/use-cases/exercise-category.use-cases';
 import { ExerciseUseCase } from '../modules/training/application/use-cases/exercise.use-cases';

--- a/apps/web/src/features/athletes/athlete-detail.tsx
+++ b/apps/web/src/features/athletes/athlete-detail.tsx
@@ -19,10 +19,10 @@ import { useTranslation } from '@dropit/i18n';
 import {
   AthleteDetailsDto,
   CompetitorLevel,
-  CreateCompetitorStatus,
+  CreateCompetitorStatusInput,
   PersonalRecordDto,
   SexCategory,
-  UpdateCompetitorStatus,
+  UpdateCompetitorStatusInput,
 } from '@dropit/schemas';
 import { Label } from '@radix-ui/react-dropdown-menu';
 import {
@@ -46,14 +46,14 @@ type AthleteDetailProps = {
   isCreatingCompetitorStatus: boolean;
   setIsCreatingCompetitorStatus: (isCreating: boolean) => void;
   updateCompetitorStatusForm: ReturnType<
-    typeof useForm<UpdateCompetitorStatus>
+    typeof useForm<UpdateCompetitorStatusInput>
   >;
   createCompetitorStatusForm: ReturnType<
-    typeof useForm<CreateCompetitorStatus>
+    typeof useForm<CreateCompetitorStatusInput>
   >;
   isLoading: boolean;
-  onUpdateCompetitorStatus: (data: UpdateCompetitorStatus) => void;
-  onCreateCompetitorStatus: (data: CreateCompetitorStatus) => void;
+  onUpdateCompetitorStatus: (data: UpdateCompetitorStatusInput) => void;
+  onCreateCompetitorStatus: (data: CreateCompetitorStatusInput) => void;
 };
 
 export function AthleteDetail({

--- a/apps/web/src/features/complex/complex-category-creation-form.tsx
+++ b/apps/web/src/features/complex/complex-category-creation-form.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import {
-  CreateComplexCategory,
+  CreateComplexCategoryInput,
   createComplexCategorySchema,
 } from '@dropit/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -33,7 +33,7 @@ export function ComplexCategoryCreationForm({
   const { toast } = useToast();
 
   const { mutate: createCategoryMutation } = useMutation({
-    mutationFn: async (data: CreateComplexCategory) => {
+    mutationFn: async (data: CreateComplexCategoryInput) => {
       const response = await api.complexCategory.createComplexCategory({
         body: data,
       });

--- a/apps/web/src/features/complex/complex-creation-form.tsx
+++ b/apps/web/src/features/complex/complex-creation-form.tsx
@@ -28,7 +28,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { CreateComplex, createComplexSchema } from '@dropit/schemas';
+import { CreateComplexInput, createComplexSchema } from '@dropit/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PlusCircle } from 'lucide-react';
@@ -74,7 +74,7 @@ export function ComplexCreationForm({
   });
 
   const { mutateAsync: createComplexMutation } = useMutation({
-    mutationFn: async (data: CreateComplex) => {
+    mutationFn: async (data: CreateComplexInput) => {
       const response = await api.complex.createComplex({ body: data });
       if (response.status !== 201) {
         throw new Error('Erreur lors de la création du complex');

--- a/apps/web/src/features/complex/complex-detail.tsx
+++ b/apps/web/src/features/complex/complex-detail.tsx
@@ -36,7 +36,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import {
   ComplexDto,
-  UpdateComplex,
+  UpdateComplexInput,
   updateComplexSchema,
 } from '@dropit/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -144,7 +144,7 @@ export function ComplexDetail({ complex }: ComplexDetailProps) {
   });
 
   const { mutate: updateComplexMutation } = useMutation({
-    mutationFn: async (data: UpdateComplex) => {
+    mutationFn: async (data: UpdateComplexInput) => {
       const response = await api.complex.updateComplex({
         params: { id: complex.id },
         body: data,

--- a/apps/web/src/features/exercises/exercise-creation-form.tsx
+++ b/apps/web/src/features/exercises/exercise-creation-form.tsx
@@ -18,7 +18,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { CreateExercise, createExerciseSchema } from '@dropit/schemas';
+import { CreateExerciseInput, createExerciseSchema } from '@dropit/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
@@ -47,7 +47,7 @@ export function ExerciseCreationForm({
   });
 
   const { mutateAsync: createExerciseMutation } = useMutation({
-    mutationFn: async (data: CreateExercise) => {
+    mutationFn: async (data: CreateExerciseInput) => {
       const response = await api.exercise.createExercise({ body: data });
       if (response.status !== 201) {
         throw new Error("Erreur lors de la création de l'exercice");

--- a/apps/web/src/features/exercises/exercise-detail.tsx
+++ b/apps/web/src/features/exercises/exercise-detail.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
-import { UpdateExercise, updateExerciseSchema } from '@dropit/schemas';
+import { UpdateExerciseInput, updateExerciseSchema } from '@dropit/schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
@@ -61,7 +61,7 @@ export function ExerciseDetail({ exercise }: ExerciseDetailProps) {
   });
 
   const { mutate: updateExerciseMutation } = useMutation({
-    mutationFn: async (data: UpdateExercise) => {
+    mutationFn: async (data: UpdateExerciseInput) => {
       const response = await api.exercise.updateExercise({
         params: { id: exercise.id },
         body: data,

--- a/apps/web/src/features/planning/create-workout-modal.tsx
+++ b/apps/web/src/features/planning/create-workout-modal.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/components/ui/dialog';
 import { Steps } from '@/components/ui/steps';
 import { useTranslation } from '@dropit/i18n';
-import { CreateWorkout } from '@dropit/schemas';
+import { CreateWorkoutInput } from '@dropit/schemas';
 import { format } from 'date-fns';
 import { enGB, fr } from 'date-fns/locale';
 import { useState } from 'react';
@@ -27,7 +27,7 @@ export function CreateWorkoutModal({
   const locale = i18n.language === 'fr' ? fr : enGB;
   const [currentStep, setCurrentStep] = useState(0);
 
-  const handleSubmitSuccess = (data: CreateWorkout) => {
+  const handleSubmitSuccess = (data: CreateWorkoutInput) => {
     // Ici vous pourriez traiter les données du workout si nécessaire
     console.log(data);
     onClose();

--- a/apps/web/src/routes/_home/athletes.$athleteId.tsx
+++ b/apps/web/src/routes/_home/athletes.$athleteId.tsx
@@ -1,31 +1,31 @@
-import { AthleteDetail } from '@/features/athletes/athlete-detail';
-import { api } from '@/lib/api';
-import { toast } from '@/hooks/use-toast';
-import { usePageMeta } from '@/hooks/use-page-meta';
-import { useTranslation } from '@dropit/i18n';
+import { AthleteDetail } from "@/features/athletes/athlete-detail";
+import { api } from "@/lib/api";
+import { toast } from "@/hooks/use-toast";
+import { usePageMeta } from "@/hooks/use-page-meta";
+import { useTranslation } from "@dropit/i18n";
 import {
   CompetitorLevel,
-  CreateCompetitorStatus,
+  CreateCompetitorStatusInput,
   SexCategory,
-  UpdateCompetitorStatus,
+  UpdateCompetitorStatusInput,
   createCompetitorStatusSchema,
   updateCompetitorStatusSchema,
-} from '@dropit/schemas';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { ScrollArea } from '@/components/ui/scroll-area';
+} from "@dropit/schemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
-export const Route = createFileRoute('/_home/athletes/$athleteId')({
+export const Route = createFileRoute("/_home/athletes/$athleteId")({
   component: AthleteDetailPage,
 });
 
 function AthleteDetailPage() {
   const { athleteId } = Route.useParams();
   const navigate = Route.useNavigate();
-  const { t } = useTranslation(['common', 'athletes']);
+  const { t } = useTranslation(["common", "athletes"]);
   const { setPageMeta } = usePageMeta();
   const [isEditingCompetitorStatus, setIsEditingCompetitorStatus] =
     useState(false);
@@ -35,13 +35,13 @@ function AthleteDetailPage() {
   const queryClient = useQueryClient();
 
   const { data: athlete, isLoading: athleteLoading } = useQuery({
-    queryKey: ['athlete', athleteId],
+    queryKey: ["athlete", athleteId],
     queryFn: async () => {
       const response = await api.athlete.getAthlete({
         params: { id: athleteId },
       });
       if (response.status !== 200)
-        throw new Error('Failed to load athlete details');
+        throw new Error("Failed to load athlete details");
       return response.body;
     },
   });
@@ -49,7 +49,7 @@ function AthleteDetailPage() {
   // Fetch all personal records for the athlete
   const { data: personalRecords, isLoading: personalRecordsLoading } = useQuery(
     {
-      queryKey: ['personalRecords', athleteId],
+      queryKey: ["personalRecords", athleteId],
       queryFn: async () => {
         // Don't execute if athlete is not loaded yet
         if (!athlete?.id) return null;
@@ -60,17 +60,17 @@ function AthleteDetailPage() {
         });
 
         if (response.status !== 200)
-          throw new Error('Failed to load personal records');
+          throw new Error("Failed to load personal records");
         return response.body;
       },
       enabled: !!athlete?.id, // Only run if athlete.id exists
-    }
+    },
   );
 
   // L'erreur de linter indique que ces variables ne sont pas utilisées, mais gardons
   // la requête pour s'assurer que les données sont chargées - potentiel usage futur
   useQuery({
-    queryKey: ['competitorStatus', athleteId],
+    queryKey: ["competitorStatus", athleteId],
     queryFn: async () => {
       // Ne pas exécuter la requête si l'athlète n'est pas encore chargé
       if (!athlete?.id) return null;
@@ -79,22 +79,22 @@ function AthleteDetailPage() {
         params: { id: athlete.id },
       });
       if (response.status !== 200)
-        throw new Error('Failed to load competitor status');
+        throw new Error("Failed to load competitor status");
       return response.body;
     },
     enabled: !!athlete?.id, // Exécuter seulement si athlete.id existe
   });
 
   // Mutation for creating a new competitor status
-  const createCompetitorStatus = async (data: CreateCompetitorStatus) => {
+  const createCompetitorStatus = async (data: CreateCompetitorStatusInput) => {
     setIsLoading(true);
     try {
       // S'assurer que athlete existe
       if (!athlete) {
-        throw new Error('Athlète non trouvé');
+        throw new Error("Athlète non trouvé");
       }
 
-      const requestBody: CreateCompetitorStatus = {
+      const requestBody: CreateCompetitorStatusInput = {
         level: data.level,
         sexCategory: data.sexCategory,
         weightCategory: data.weightCategory,
@@ -107,24 +107,24 @@ function AthleteDetailPage() {
 
       if (response.status !== 201) {
         throw new Error(
-          "Erreur lors de la création du nouveau statut compétitif de l'athlète"
+          "Erreur lors de la création du nouveau statut compétitif de l'athlète",
         );
       }
       toast({
-        title: 'Nouveau statut compétitif créé',
+        title: "Nouveau statut compétitif créé",
         description:
           "Un nouveau statut compétitif a été créé pour l'athlète, l'ancien statut a été archivé",
       });
       setIsCreatingCompetitorStatus(false);
-      queryClient.invalidateQueries({ queryKey: ['athletes'] });
-      queryClient.invalidateQueries({ queryKey: ['athlete', athleteId] });
+      queryClient.invalidateQueries({ queryKey: ["athletes"] });
+      queryClient.invalidateQueries({ queryKey: ["athlete", athleteId] });
       return response.body;
     } catch (error: unknown) {
       toast({
-        title: 'Erreur',
+        title: "Erreur",
         description:
-          error instanceof Error ? error.message : 'Une erreur est survenue',
-        variant: 'destructive',
+          error instanceof Error ? error.message : "Une erreur est survenue",
+        variant: "destructive",
       });
     } finally {
       setIsLoading(false);
@@ -132,12 +132,12 @@ function AthleteDetailPage() {
   };
 
   // Mutation for updating athlete competitor status (correction only)
-  const updateCompetitorStatus = async (data: UpdateCompetitorStatus) => {
+  const updateCompetitorStatus = async (data: UpdateCompetitorStatusInput) => {
     setIsLoading(true);
     try {
       // Vérifier que l'athlète existe
       if (!athlete) {
-        throw new Error('Athlète non trouvé');
+        throw new Error("Athlète non trouvé");
       }
 
       // Obtenir le dernier statut compétitif avec l'ID via une requête dédiée
@@ -146,13 +146,13 @@ function AthleteDetailPage() {
       });
 
       if (getStatusResponse.status !== 200 || !getStatusResponse.body.id) {
-        throw new Error('Impossible de récupérer le statut compétitif actuel');
+        throw new Error("Impossible de récupérer le statut compétitif actuel");
       }
 
       // Utiliser l'ID obtenu de la réponse pour la mise à jour
       const competitorStatusId = getStatusResponse.body.id;
 
-      const requestBody: UpdateCompetitorStatus = {
+      const requestBody: UpdateCompetitorStatusInput = {
         level: data.level,
         sexCategory: data.sexCategory,
         weightCategory: data.weightCategory,
@@ -165,27 +165,27 @@ function AthleteDetailPage() {
 
       if (response.status !== 200) {
         throw new Error(
-          "Erreur lors de la correction du statut compétitif de l'athlète"
+          "Erreur lors de la correction du statut compétitif de l'athlète",
         );
       }
       toast({
-        title: 'Statut compétitif corrigé avec succès',
+        title: "Statut compétitif corrigé avec succès",
         description:
           "Le statut compétitif de l'athlète a été corrigé avec succès",
       });
       setIsEditingCompetitorStatus(false);
-      queryClient.invalidateQueries({ queryKey: ['athletes'] });
-      queryClient.invalidateQueries({ queryKey: ['athlete', athleteId] });
+      queryClient.invalidateQueries({ queryKey: ["athletes"] });
+      queryClient.invalidateQueries({ queryKey: ["athlete", athleteId] });
       queryClient.invalidateQueries({
-        queryKey: ['competitorStatus', athleteId],
+        queryKey: ["competitorStatus", athleteId],
       });
       return response.body;
     } catch (error: unknown) {
       toast({
-        title: 'Erreur',
+        title: "Erreur",
         description:
-          error instanceof Error ? error.message : 'Une erreur est survenue',
-        variant: 'destructive',
+          error instanceof Error ? error.message : "Une erreur est survenue",
+        variant: "destructive",
       });
     } finally {
       setIsLoading(false);
@@ -193,7 +193,7 @@ function AthleteDetailPage() {
   };
 
   // Form setup for updating competitor status
-  const updateCompetitorStatusForm = useForm<UpdateCompetitorStatus>({
+  const updateCompetitorStatusForm = useForm<UpdateCompetitorStatusInput>({
     resolver: zodResolver(updateCompetitorStatusSchema),
     defaultValues: {
       level: CompetitorLevel.ROOKIE,
@@ -203,7 +203,7 @@ function AthleteDetailPage() {
   });
 
   // Form setup for creating competitor status
-  const createCompetitorStatusForm = useForm<CreateCompetitorStatus>({
+  const createCompetitorStatusForm = useForm<CreateCompetitorStatusInput>({
     resolver: zodResolver(createCompetitorStatusSchema),
     defaultValues: {
       level: CompetitorLevel.ROOKIE,
@@ -229,16 +229,16 @@ function AthleteDetailPage() {
       setPageMeta({
         title: `${athlete.firstName} ${athlete.lastName}`,
         showBackButton: true,
-        onBackClick: () => navigate({ to: '/athletes' })
+        onBackClick: () => navigate({ to: "/athletes" }),
       });
     }
 
     // Cleanup: reset to default when leaving the page
     return () => {
       setPageMeta({
-        title: t('common:routes./athletes'),
+        title: t("common:routes./athletes"),
         showBackButton: false,
-        onBackClick: undefined
+        onBackClick: undefined,
       });
     };
   }, [athlete, setPageMeta, navigate, t]);
@@ -246,13 +246,13 @@ function AthleteDetailPage() {
   if (athleteLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
-        {t('common:loading')}
+        {t("common:loading")}
       </div>
     );
   }
 
   if (!athlete) {
-    return <div>{t('common:not_found')}</div>;
+    return <div>{t("common:not_found")}</div>;
   }
 
   return (

--- a/apps/web/src/routes/_home/workouts.create.tsx
+++ b/apps/web/src/routes/_home/workouts.create.tsx
@@ -3,7 +3,7 @@ import { api } from '@/lib/api';
 import { Steps } from '@/components/ui/steps';
 import { useToast } from '@/hooks/use-toast';
 import { usePageMeta } from '@/hooks/use-page-meta';
-import { CreateWorkout } from '@dropit/schemas';
+import { CreateWorkoutInput } from '@dropit/schemas';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { useCallback, useEffect, useState } from 'react';
@@ -27,7 +27,7 @@ function CreateWorkoutPage() {
 
   // Mutation pour créer un workout
   const { mutate: createWorkoutMutation } = useMutation({
-    mutationFn: async (data: CreateWorkout) => {
+    mutationFn: async (data: CreateWorkoutInput) => {
       const response = await api.workout.createWorkout({ body: data });
       if (response.status !== 201) {
         throw new Error('Erreur lors de la création du workout');
@@ -52,7 +52,7 @@ function CreateWorkoutPage() {
     },
   });
 
-  const handleCreationSuccess = (data: CreateWorkout) => {
+  const handleCreationSuccess = (data: CreateWorkoutInput) => {
     createWorkoutMutation(data);
     if (data.trainingSession?.scheduledDate) {
       navigate({ to: '/planning', replace: true, search: { date: data.trainingSession.scheduledDate } });

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -640,7 +640,11 @@ async function main(): Promise<void> {
             console.log(`  ${colorize('ℹ', 'blue')} Pending migrations detected`)
             const dbChoice = await select(
               'How do you want to set up the database?',
-              ['Apply migrations (db:migration:up)', 'Fresh database with seeds (db:fresh)', 'Skip'],
+              [
+                'Apply migrations (db:migration:up)',
+                'Create database + migrate + seed (db:create + db:seed)',
+                'Skip',
+              ],
               0,
             )
 
@@ -654,21 +658,25 @@ async function main(): Promise<void> {
                   `  ${colorize('You can run migrations manually later with:', 'dim')} ${colorize('pnpm --filter api db:migration:up', 'bright')}`,
                 )
               }
-            } else if (dbChoice.includes('Fresh database')) {
+            } else if (dbChoice.includes('Create database')) {
               try {
-                await runCommand('pnpm', ['db:fresh'])
+                await runCommand('pnpm', ['--filter', 'api', 'db:create'])
+                await runCommand('pnpm', ['--filter', 'api', 'db:seed'])
                 console.log(
-                  `\n  ${colorize('✓', 'green')} Fresh database created and seeded successfully`,
+                  `\n  ${colorize('✓', 'green')} Database created, migrated, and seeded successfully`,
                 )
               } catch (error) {
-                console.error(`\n  ${colorize('⚠', 'yellow')} db:fresh failed:`, error)
+                console.error(
+                  `\n  ${colorize('⚠', 'yellow')} db:create + db:seed failed:`,
+                  error,
+                )
                 console.log(
-                  `  ${colorize('You can run db:fresh manually later with:', 'dim')} ${colorize('pnpm db:fresh', 'bright')}`,
+                  `  ${colorize('You can run setup manually later with:', 'dim')} ${colorize('pnpm --filter api db:create && pnpm --filter api db:seed', 'bright')}`,
                 )
               }
             } else {
               console.log(
-                `  ${colorize('→', 'cyan')} Skipped database setup. Run manually with: ${colorize('pnpm --filter api db:migration:up', 'bright')} or ${colorize('pnpm db:fresh', 'bright')}`,
+                `  ${colorize('→', 'cyan')} Skipped database setup. Run manually with: ${colorize('pnpm --filter api db:create && pnpm --filter api db:seed', 'bright')} or ${colorize('pnpm --filter api db:migration:up', 'bright')}`,
               )
             }
           } else {
@@ -677,7 +685,7 @@ async function main(): Promise<void> {
 
             if (shouldSeed) {
               try {
-                await runCommand('pnpm', ['db:seed'])
+                await runCommand('pnpm', ['--filter', 'api', 'db:seed'])
                 console.log(`\n  ${colorize('✓', 'green')} Database seeded successfully`)
               } catch (error) {
                 console.error(`\n  ${colorize('⚠', 'yellow')} Seeding failed:`, error)
@@ -712,7 +720,7 @@ async function main(): Promise<void> {
       )
       step++
       console.log(
-        `  ${colorize(`${step}.`, 'bright')} Run database setup: ${colorize('pnpm db:fresh', 'blue')} or ${colorize('pnpm --filter api db:migration:up', 'blue')}`,
+        `  ${colorize(`${step}.`, 'bright')} Run database setup: ${colorize('pnpm --filter api db:create && pnpm --filter api db:seed', 'blue')}`,
       )
       step++
     }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
   test-db:
     image: postgres:15-alpine
     environment:
-      POSTGRES_NAME: ${DB_NAME_TEST}
+      POSTGRES_DB: ${DB_NAME_TEST}
       POSTGRES_USER: ${DB_USER_TEST}
       POSTGRES_PASSWORD: ${DB_PASSWORD_TEST}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_NAME: ${DB_NAME}
+      POSTGRES_DB: ${DB_NAME}
     ports:
       - "${DB_PORT:-5432}:5432"
     volumes:

--- a/packages/schemas/src/access.schema.ts
+++ b/packages/schemas/src/access.schema.ts
@@ -5,6 +5,4 @@ export const accessSchema = z.object({
   name: z.string().min(1, 'Name is required'),
 })
 
-export type RequestAccess = z.infer<typeof accessSchema>;
-
-
+export type RequestAccessInput = z.infer<typeof accessSchema>;

--- a/packages/schemas/src/athlete-training-session.schema.ts
+++ b/packages/schemas/src/athlete-training-session.schema.ts
@@ -6,13 +6,13 @@ export const createAthleteTrainingSessionSchema = z.object({
   notes_athlete: z.string().optional(),
 });
 
-export type CreateAthleteTrainingSession = z.infer<typeof createAthleteTrainingSessionSchema>;
+export type CreateAthleteTrainingSessionInput = z.infer<typeof createAthleteTrainingSessionSchema>;
 
 export const updateAthleteTrainingSessionSchema = z.object({
   notes_athlete: z.string().optional(),
 });
 
-export type UpdateAthleteTrainingSession = z.infer<typeof updateAthleteTrainingSessionSchema>;
+export type UpdateAthleteTrainingSessionInput = z.infer<typeof updateAthleteTrainingSessionSchema>;
 
 export const athleteTrainingSessionSchema = z.object({
   athleteId: z.string(),

--- a/packages/schemas/src/athlete.schema.ts
+++ b/packages/schemas/src/athlete.schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 export const createAthleteSchema = z.object({
   firstName: z.string(),
@@ -7,11 +7,11 @@ export const createAthleteSchema = z.object({
   country: z.string().optional(),
 });
 
-export type CreateAthlete = z.infer<typeof createAthleteSchema>;
+export type CreateAthleteInput = z.infer<typeof createAthleteSchema>;
 
 export const updateAthleteSchema = createAthleteSchema.partial();
 
-export type UpdateAthlete = z.infer<typeof updateAthleteSchema>;
+export type UpdateAthleteInput = z.infer<typeof updateAthleteSchema>;
 
 export const athleteSchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/common.schema.ts
+++ b/packages/schemas/src/common.schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 /**
  * Reusable schema for date filtering
@@ -17,5 +17,5 @@ export const dateRangeFilterSchema = z.object({
   endDate: z.string().date().optional(),
 });
 
-export type DateFilter = z.infer<typeof dateFilterSchema>;
-export type DateRangeFilter = z.infer<typeof dateRangeFilterSchema>;
+export type DateFilterInput = z.infer<typeof dateFilterSchema>;
+export type DateRangeFilterInput = z.infer<typeof dateRangeFilterSchema>;

--- a/packages/schemas/src/competitor-status.schema.ts
+++ b/packages/schemas/src/competitor-status.schema.ts
@@ -20,14 +20,14 @@ export const createCompetitorStatusSchema = z.object({
   athleteId: z.string(),
 });
 
-export type CreateCompetitorStatus = z.infer<
+export type CreateCompetitorStatusInput = z.infer<
   typeof createCompetitorStatusSchema
 >;
 
 export const updateCompetitorStatusSchema =
   createCompetitorStatusSchema.partial();
 
-export type UpdateCompetitorStatus = z.infer<
+export type UpdateCompetitorStatusInput = z.infer<
   typeof updateCompetitorStatusSchema
 >;
 

--- a/packages/schemas/src/complex-category.schema.ts
+++ b/packages/schemas/src/complex-category.schema.ts
@@ -4,11 +4,11 @@ export const createComplexCategorySchema = z.object({
   name: z.string(),
 });
 
-export type CreateComplexCategory = z.infer<typeof createComplexCategorySchema>;
+export type CreateComplexCategoryInput = z.infer<typeof createComplexCategorySchema>;
 
 export const updateComplexCategorySchema = createComplexCategorySchema;
 
-export type UpdateComplexCategory = z.infer<typeof updateComplexCategorySchema>;
+export type UpdateComplexCategoryInput = z.infer<typeof updateComplexCategorySchema>;
 
 export const complexCategorySchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/complex.schema.ts
+++ b/packages/schemas/src/complex.schema.ts
@@ -11,14 +11,14 @@ export const createComplexSchema = z.object({
   exercises: z.array(createExerciseComplexSchema),
 });
 
-export type CreateComplex = z.infer<typeof createComplexSchema>;
+export type CreateComplexInput = z.infer<typeof createComplexSchema>;
 
 export const updateComplexSchema = z.object({
   complexCategory: z.string().optional(),
   exercises: z.array(createExerciseComplexSchema).optional(),
 });
 
-export type UpdateComplex = z.infer<typeof updateComplexSchema>;
+export type UpdateComplexInput = z.infer<typeof updateComplexSchema>;
 
 const exerciseComplexSchema = exerciseSchema.extend({
   order: z.number(),

--- a/packages/schemas/src/exercice.schema.ts
+++ b/packages/schemas/src/exercice.schema.ts
@@ -8,11 +8,11 @@ export const createExerciseSchema = z.object({
   shortName: z.string().optional(),
 });
 
-export type CreateExercise = z.infer<typeof createExerciseSchema>;
+export type CreateExerciseInput = z.infer<typeof createExerciseSchema>;
 
 export const updateExerciseSchema = createExerciseSchema.partial();
 
-export type UpdateExercise = z.infer<typeof updateExerciseSchema>;
+export type UpdateExerciseInput = z.infer<typeof updateExerciseSchema>;
 
 export const exerciseSchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/exercise-category.schema.ts
+++ b/packages/schemas/src/exercise-category.schema.ts
@@ -4,13 +4,13 @@ export const createExerciseCategorySchema = z.object({
   name: z.string(),
 });
 
-export type CreateExerciseCategory = z.infer<
+export type CreateExerciseCategoryInput = z.infer<
   typeof createExerciseCategorySchema
 >;
 
 export const updateExerciseCategorySchema = createExerciseCategorySchema;
 
-export type UpdateExerciseCategory = z.infer<
+export type UpdateExerciseCategoryInput = z.infer<
   typeof updateExerciseCategorySchema
 >;
 

--- a/packages/schemas/src/personal-record.schema.ts
+++ b/packages/schemas/src/personal-record.schema.ts
@@ -10,7 +10,7 @@ export const createPersonalRecordSchema = z.object({
   exerciseId: z.string(),
 });
 
-export type CreatePersonalRecord = z.infer<typeof createPersonalRecordSchema>;
+export type CreatePersonalRecordInput = z.infer<typeof createPersonalRecordSchema>;
 
 export const updatePersonalRecordSchema = createPersonalRecordSchema
   .partial()
@@ -19,7 +19,7 @@ export const updatePersonalRecordSchema = createPersonalRecordSchema
     exerciseId: true,
   });
 
-export type UpdatePersonalRecord = z.infer<typeof updatePersonalRecordSchema>;
+export type UpdatePersonalRecordInput = z.infer<typeof updatePersonalRecordSchema>;
 
 export const personalRecordSchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/training-session.schema.ts
+++ b/packages/schemas/src/training-session.schema.ts
@@ -7,7 +7,7 @@ export const createTrainingSessionSchema = z.object({
   scheduledDate: z.string().or(z.date()),
 });
 
-export type CreateTrainingSession = z.infer<typeof createTrainingSessionSchema>;
+export type CreateTrainingSessionInput = z.infer<typeof createTrainingSessionSchema>;
 
 export const updateTrainingSessionSchema = z.object({
   workoutId: z.string().optional(),
@@ -16,7 +16,7 @@ export const updateTrainingSessionSchema = z.object({
   completedDate: z.string().or(z.date()).optional(),
 });
 
-export type UpdateTrainingSession = z.infer<typeof updateTrainingSessionSchema>;
+export type UpdateTrainingSessionInput = z.infer<typeof updateTrainingSessionSchema>;
 
 export const trainingSessionSchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/user.schema.ts
+++ b/packages/schemas/src/user.schema.ts
@@ -6,7 +6,7 @@ export const updateUserSchema = z.object({
   image: z.string().optional(),
 });
 
-export type UpdateUser = z.infer<typeof updateUserSchema>;
+export type UpdateUserInput = z.infer<typeof updateUserSchema>;
 
 export const userSchema = z.object({
   id: z.string(),
@@ -27,4 +27,4 @@ export const deleteUserSchema = z.object({
   confirmation: z.string().min(1, 'Confirmation is required'),
 });
 
-export type DeleteUser = z.infer<typeof deleteUserSchema>;
+export type DeleteUserInput = z.infer<typeof deleteUserSchema>;

--- a/packages/schemas/src/workout-category.schema.ts
+++ b/packages/schemas/src/workout-category.schema.ts
@@ -4,11 +4,11 @@ export const createWorkoutCategorySchema = z.object({
   name: z.string(),
 });
 
-export type CreateWorkoutCategory = z.infer<typeof createWorkoutCategorySchema>;
+export type CreateWorkoutCategoryInput = z.infer<typeof createWorkoutCategorySchema>;
 
 export const updateWorkoutCategorySchema = createWorkoutCategorySchema;
 
-export type UpdateWorkoutCategory = z.infer<typeof updateWorkoutCategorySchema>;
+export type UpdateWorkoutCategoryInput = z.infer<typeof updateWorkoutCategorySchema>;
 
 export const workoutCategorySchema = z.object({
   id: z.string(),

--- a/packages/schemas/src/workout.schema.ts
+++ b/packages/schemas/src/workout.schema.ts
@@ -74,11 +74,11 @@ export const createWorkoutSchema = z.object({
   trainingSession: createTrainingSessionWithWorkoutSchema.optional(),
 });
 
-export type CreateWorkout = z.infer<typeof createWorkoutSchema>;
+export type CreateWorkoutInput = z.infer<typeof createWorkoutSchema>;
 
 export const updateWorkoutSchema = createWorkoutSchema.partial();
 
-export type UpdateWorkout = z.infer<typeof updateWorkoutSchema>;
+export type UpdateWorkoutInput = z.infer<typeof updateWorkoutSchema>;
 
 const workoutExerciseElement = z.object({
   id: z.string(),


### PR DESCRIPTION
Rename schema imports from Create*/Update* to *Input variants across use cases, forms, and routes to keep contract typing consistent, and update setup docs/compose config for the new DB create + seed flow.